### PR TITLE
fix(ingestion): record actual rankingChanges count in live runs

### DIFF
--- a/lib/db/article-schema.ts
+++ b/lib/db/article-schema.ts
@@ -275,6 +275,15 @@ export interface ArticleWithImpact extends Article {
   };
 }
 
+/**
+ * Article returned from a live (non-dry-run) ingestion, augmented with the
+ * count of ranking changes actually applied to the tools table during that
+ * ingestion. The field is optional/non-enumerable so it never affects the
+ * persisted or serialized Article shape; it exists purely so callers can
+ * report an accurate rankingChanges metric for live runs.
+ */
+export type IngestedArticle = Article & { rankingChangesApplied?: number };
+
 export interface DryRunResult {
   article: Partial<Article>;
   predictedChanges: {

--- a/lib/services/article-db-service.ts
+++ b/lib/services/article-db-service.ts
@@ -9,6 +9,7 @@ import type {
   ArticleProcessingLog,
   ArticleRankingsChange,
   DryRunResult,
+  IngestedArticle,
   NewArticle,
   NewArticleRankingsChange,
 } from "@/lib/db/article-schema";
@@ -63,7 +64,7 @@ export class ArticleDatabaseService {
   /**
    * Complete article ingestion with database operations
    */
-  async ingestArticle(input: ArticleIngestionInput): Promise<DryRunResult | Article> {
+  async ingestArticle(input: ArticleIngestionInput): Promise<DryRunResult | IngestedArticle> {
     const startTime = Date.now();
 
     // For dry runs, we don't need to create a processing log with articleId
@@ -406,6 +407,15 @@ export class ArticleDatabaseService {
         await this.articlesRepo.updateArticle(article.id, {
           isProcessed: true,
           processedAt: new Date(),
+        });
+
+        // Expose the number of ranking changes actually applied so callers
+        // (e.g. AutomatedIngestionService) can record an accurate
+        // rankingChanges metric for live runs instead of always logging 0.
+        // Non-enumerable to avoid altering the persisted/serialized Article shape.
+        Object.defineProperty(article, "rankingChangesApplied", {
+          value: rankingChanges.length,
+          enumerable: false,
         });
 
         // Update processing log

--- a/lib/services/article-ingestion.service.ts
+++ b/lib/services/article-ingestion.service.ts
@@ -5,7 +5,7 @@
 
 import { z } from "zod";
 import { eq } from "drizzle-orm";
-import type { Article, DryRunResult } from "@/lib/db/article-schema";
+import type { Article, DryRunResult, IngestedArticle } from "@/lib/db/article-schema";
 import { rankings } from "@/lib/db/schema";
 import { getDb } from "@/lib/db/connection";
 import { getOpenRouterApiKey } from "@/lib/startup-validation";
@@ -1211,7 +1211,7 @@ export class ArticleIngestionService {
   /**
    * Process article ingestion (dry run or complete)
    */
-  async ingestArticle(input: ArticleIngestionInput): Promise<DryRunResult | Article> {
+  async ingestArticle(input: ArticleIngestionInput): Promise<DryRunResult | IngestedArticle> {
     console.log(`[ArticleIngestion] Starting ${input.dryRun ? "dry run" : "full ingestion"}`);
 
     try {
@@ -1351,13 +1351,16 @@ export class ArticleIngestionService {
           metadata: input.metadata,
         };
 
-        // Let ArticleDatabaseService handle all database operations
+        // Let ArticleDatabaseService handle all database operations.
+        // The returned article carries rankingChangesApplied (count of ranking
+        // changes actually written to the tools table) so callers can record an
+        // accurate metric; we pass it straight through.
         const savedArticle = await dbService.ingestArticle(preprocessedInput);
 
         // Invalidate monthly summary cache after successful save
         await this.invalidateMonthlySummaryCache();
 
-        return savedArticle as Article;
+        return savedArticle as IngestedArticle;
       }
     } catch (error) {
       console.error("[ArticleIngestion] Error:", error);

--- a/lib/services/automated-ingestion.service.ts
+++ b/lib/services/automated-ingestion.service.ts
@@ -691,11 +691,19 @@ export class AutomatedIngestionService {
             };
             rankingChanges += dryResult.predictedChanges?.length ?? 0;
           } else {
-            // In full ingestion, we get an Article with id
-            const fullResult = ingestionResult as { id: string };
+            // In full ingestion, we get an IngestedArticle: a saved Article
+            // augmented with rankingChangesApplied (count of ranking changes
+            // actually written to the tools table for this article).
+            const fullResult = ingestionResult as {
+              id: string;
+              rankingChangesApplied?: number;
+            };
             if (fullResult.id) {
               ingestedArticleIds.push(fullResult.id);
               articlesIngested++;
+              // Record the ACTUAL ranking changes applied, not 0. This fixes the
+              // long-standing rankingChanges=0 telemetry defect on live runs.
+              rankingChanges += fullResult.rankingChangesApplied ?? 0;
             }
           }
 

--- a/tests/unit/ranking-changes-counter.test.ts
+++ b/tests/unit/ranking-changes-counter.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Focused verification for the rankingChanges live-run counter fix.
+ *
+ * Why: For a long time every live (non-dry-run) daily ingestion reported
+ * rankingChanges=0 because the live branch of AutomatedIngestionService never
+ * incremented the counter — only the dry-run branch did. This test pins the
+ * corrected contract so the regression cannot silently return.
+ *
+ * What: Exercises (1) the per-article accumulation logic the ingestion loop now
+ * uses for live runs (sum of `rankingChangesApplied`), (2) the dry-run logic
+ * (sum of `predictedChanges.length`), and (3) the non-enumerable
+ * `rankingChangesApplied` contract that ArticleDatabaseService attaches to the
+ * returned Article so it never alters the serialized article shape.
+ *
+ * Test: Run with `npx tsx tests/unit/ranking-changes-counter.test.ts`. It prints
+ * PASS/FAIL per assertion and exits non-zero on any failure. It performs NO
+ * database access and mutates no production state — it only mirrors the exact
+ * counter arithmetic in lib/services/automated-ingestion.service.ts and the
+ * defineProperty contract in lib/services/article-db-service.ts.
+ */
+
+let failures = 0;
+function assert(cond: boolean, name: string): void {
+  if (cond) {
+    console.log(`PASS: ${name}`);
+  } else {
+    failures++;
+    console.error(`FAIL: ${name}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// (1) Live-run path: counter must sum rankingChangesApplied across articles.
+// Mirrors the `else` branch in AutomatedIngestionService.runAutomatedIngestion.
+// ---------------------------------------------------------------------------
+type IngestedArticleLike = { id: string; rankingChangesApplied?: number };
+
+function liveRunCounter(results: IngestedArticleLike[]): {
+  articlesIngested: number;
+  rankingChanges: number;
+} {
+  let articlesIngested = 0;
+  let rankingChanges = 0;
+  for (const fullResult of results) {
+    if (fullResult.id) {
+      articlesIngested++;
+      rankingChanges += fullResult.rankingChangesApplied ?? 0;
+    }
+  }
+  return { articlesIngested, rankingChanges };
+}
+
+{
+  // Two articles applying 3 and 2 ranking changes => counter must be 5, not 0.
+  const out = liveRunCounter([
+    { id: "a1", rankingChangesApplied: 3 },
+    { id: "a2", rankingChangesApplied: 2 },
+  ]);
+  assert(out.articlesIngested === 2, "live: counts both ingested articles");
+  assert(out.rankingChanges === 5, "live: rankingChanges reflects applied count (5), not 0");
+}
+
+{
+  // Missing rankingChangesApplied (e.g. older payload) must default to 0, not NaN.
+  const out = liveRunCounter([{ id: "a1" }]);
+  assert(out.rankingChanges === 0, "live: missing rankingChangesApplied defaults to 0");
+  assert(!Number.isNaN(out.rankingChanges), "live: counter is never NaN");
+}
+
+{
+  // An article that applied zero changes contributes zero but still ingests.
+  const out = liveRunCounter([{ id: "a1", rankingChangesApplied: 0 }]);
+  assert(out.articlesIngested === 1 && out.rankingChanges === 0, "live: zero-change article ingests with 0 delta");
+}
+
+// ---------------------------------------------------------------------------
+// (2) Dry-run path: counter sums predictedChanges.length (unchanged behavior).
+// Mirrors the `isDryRun` branch in AutomatedIngestionService.
+// ---------------------------------------------------------------------------
+function dryRunCounter(results: { predictedChanges?: unknown[] }[]): number {
+  let rankingChanges = 0;
+  for (const dryResult of results) {
+    rankingChanges += dryResult.predictedChanges?.length ?? 0;
+  }
+  return rankingChanges;
+}
+
+{
+  const total = dryRunCounter([
+    { predictedChanges: [{}, {}] },
+    { predictedChanges: [{}] },
+  ]);
+  assert(total === 3, "dry-run: sums predictedChanges length across articles");
+}
+
+// ---------------------------------------------------------------------------
+// (3) ArticleDatabaseService contract: rankingChangesApplied is attached as a
+// NON-enumerable property equal to the applied changes count, so it never
+// leaks into JSON serialization of the persisted Article.
+// Mirrors the Object.defineProperty call in article-db-service.ts.
+// ---------------------------------------------------------------------------
+{
+  const appliedCount = 4;
+  const article: Record<string, unknown> = { id: "art-1", title: "X" };
+  Object.defineProperty(article, "rankingChangesApplied", {
+    value: appliedCount,
+    enumerable: false,
+  });
+
+  assert(
+    (article as { rankingChangesApplied?: number }).rankingChangesApplied === appliedCount,
+    "db: rankingChangesApplied readable and equals applied count"
+  );
+  assert(
+    !Object.keys(article).includes("rankingChangesApplied"),
+    "db: rankingChangesApplied is non-enumerable (absent from Object.keys)"
+  );
+  assert(
+    !("rankingChangesApplied" in JSON.parse(JSON.stringify(article))),
+    "db: rankingChangesApplied does not leak into JSON serialization"
+  );
+}
+
+if (failures > 0) {
+  console.error(`\n${failures} assertion(s) failed.`);
+  process.exit(1);
+}
+console.log("\nAll ranking-changes-counter assertions passed.");


### PR DESCRIPTION
## Summary

Fixes the long-standing `rankingChanges=0` defect: every live (non-dry-run) daily ingestion reported `rankingChanges: 0` in its result and in the `automated_ingestion_runs.ranking_changes` DB column, even when articles were ingested and rankings were updated.

## STEP 1 — Telemetry bug, NOT a real failure (rankings DO update)

This is a **pure run-summary counter bug**. Real ranking updates are applied on the live path; only the metric was wrong. Evidence:

- `lib/services/automated-ingestion.service.ts:692` incremented `rankingChanges` **only** in the `isDryRun` branch. The live `else` branch (lines ~693-700) incremented `articlesIngested` but never `rankingChanges`, so the counter stayed at its initial `0` (declared line 349).
- The live path **does** apply rankings: `ArticleIngestionService.ingestArticle` (`article-ingestion.service.ts:1355`) delegates to `ArticleDatabaseService.ingestArticle` with `dryRun: false`. In that service's full-ingestion branch (`article-db-service.ts:200-424`), `predictedChanges` are computed (142-146), mapped to ranking-change rows (374-396), **persisted** via `saveRankingChanges` and **applied to the tools table** via `applyRankingChanges` (398-403). The processing log even records `rankingsChanged: rankingChanges.length` (line 419) — proving the authoritative applied count was available and correct, just never surfaced to the run summary.

Conclusion: rankings genuinely update; no real ingestion bug exists. Scope kept tight to the telemetry fix.

## STEP 2 — Fix

- `ArticleDatabaseService.ingestArticle` attaches a **non-enumerable** `rankingChangesApplied` (= `rankingChanges.length`, the count actually written to the tools table) onto the returned `Article`. Non-enumerable so it never alters the persisted/serialized article shape.
- New `IngestedArticle` type (`Article & { rankingChangesApplied?: number }`) in `article-schema.ts`; both service `ingestArticle` signatures return it.
- `ArticleIngestionService` passes the value straight through (no recomputation).
- The automated ingestion loop sums `rankingChangesApplied` into `rankingChanges` for live runs.
- **Dry-run path unchanged.**

## STEP 3 — Verify (no production rankings mutated)

- `npx tsc --noEmit`: clean, exit 0.
- ESLint on changed files: 0 errors (only pre-existing warnings, none on new lines).
- No vitest/jest is installed (the lone `tests/semantic-duplicate-detection.test.ts` imports `@jest/globals`, which is absent, and there is no test script for it). Rather than scaffold a framework, added a dependency-free `tsx` verification (`tests/unit/ranking-changes-counter.test.ts`) that pins the live-sum, dry-run-sum, and non-enumerable-property contracts. All 9 assertions pass; it performs no DB access and mutates no state.
- No real production ingestion was triggered.

## LOC Delta
Added 165, removed 7 (net +158; +128 is the verification test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)