### PR TITLE
feat(ops): webhook-free ingestion-gap alerting (auto-issue + macOS notifier)

### DIFF
--- a/.github/workflows/cron-gap-detector.yml
+++ b/.github/workflows/cron-gap-detector.yml
@@ -16,6 +16,12 @@ jobs:
   check-ingestion-gap:
     name: Check last ingestion run
     runs-on: ubuntu-latest
+    # issues:write lets the post-failure step open/comment on an ingestion-alert issue
+    # using the built-in GITHUB_TOKEN — no extra secret/webhook required. contents:read
+    # is the minimum actions/checkout needs.
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -30,7 +36,94 @@ jobs:
         run: npm ci
 
       # Fails the job (non-zero exit) if no ingestion run was recorded in the last 25h.
+      # This remains the GATING step: its non-zero exit fails the workflow red so GitHub's
+      # own failed-workflow email still fires. The github-script step below is additive.
       - name: Check ingestion gap
         run: node scripts/check-ingestion-gap.mjs
         env:
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
+
+      # Louder, credential-free GitHub alert. Runs ONLY when a prior step failed (i.e. the
+      # gap check above tripped). Uses the built-in GITHUB_TOKEN via actions/github-script —
+      # no SMTP/webhook/extra secret. It never throws on its own errors (try/catch), so it
+      # cannot mask the real failure: the job still ends red because the gating step exited
+      # non-zero. On failure it opens (or comments on) a single de-duplicated tracking issue.
+      # TODO(future): add a companion `if: success()` step that auto-closes the open
+      # `ingestion-alert` issue once ingestion recovers (out of scope for this PR).
+      - name: Open or update ingestion-alert issue
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const LABEL = 'ingestion-alert';
+            const ASSIGNEE = 'bobmatnyc'; // editable: change to re-route the alert
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const ts = new Date().toISOString();
+            try {
+              // Find an existing OPEN issue carrying the ingestion-alert label so repeated
+              // failures comment on one thread instead of spamming new issues.
+              const existing = await github.rest.issues.listForRepo({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                labels: LABEL,
+                per_page: 1,
+              });
+
+              if (existing.data.length > 0) {
+                const issueNumber = existing.data[0].number;
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  body: `Gap still present as of ${ts} — ${runUrl}`,
+                });
+                core.info(`Commented on existing ingestion-alert issue #${issueNumber}`);
+                return;
+              }
+
+              const body = [
+                '🚨 **No automated ingestion run recorded in the last 25h+.**',
+                '',
+                'The daily scraper appears to be silent. A failed cron still returns 2xx, so this',
+                'gap detector queries the production DB directly and fails when no row has landed',
+                'in `automated_ingestion_runs` within the 25h threshold.',
+                '',
+                `**Failing run:** ${runUrl}`,
+                `**Detected at:** ${ts}`,
+                '',
+                '### Remediation',
+                '1. Redeploy production to re-bind `CRON_SECRET` (the recurring root cause of silent stalls).',
+                '2. Backfill the missed window via `scripts/trigger-ingestion.ts`.',
+                '',
+                '_This issue is opened automatically by the `Ingestion gap detector` workflow.',
+                'It is not auto-closed on recovery yet — close it manually once ingestion resumes._',
+              ].join('\n');
+
+              // Try to create labeled + assigned. If labeling/assignment is rejected (e.g. the
+              // label does not yet exist or the assignee is invalid), retry without them so the
+              // alert still lands.
+              try {
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: '🚨 Ingestion gap detected — daily scraper silent',
+                  body,
+                  labels: [LABEL],
+                  assignees: [ASSIGNEE],
+                });
+                core.info(`Opened ingestion-alert issue #${created.data.number}`);
+              } catch (labelErr) {
+                core.warning(`Create with label/assignee failed (${labelErr.message}); retrying without them.`);
+                const created = await github.rest.issues.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: '🚨 Ingestion gap detected — daily scraper silent',
+                  body,
+                });
+                core.info(`Opened ingestion-alert issue #${created.data.number} (no label/assignee)`);
+              }
+            } catch (err) {
+              // Never mask the real failure: log and let the job stay red from the gating step.
+              core.warning(`Could not open/update ingestion-alert issue: ${err.message}`);
+            }

--- a/.github/workflows/cron-gap-detector.yml
+++ b/.github/workflows/cron-gap-detector.yml
@@ -60,6 +60,33 @@ jobs:
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
             const ts = new Date().toISOString();
             try {
+              // Ensure the ingestion-alert label exists before we rely on it for dedup and
+              // labeled creation. If it is missing (404), create it; ignore any create race
+              // or permission hiccup so this never aborts the alert path.
+              try {
+                await github.rest.issues.getLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: LABEL,
+                });
+              } catch (getLabelErr) {
+                if (getLabelErr.status === 404) {
+                  try {
+                    await github.rest.issues.createLabel({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: LABEL,
+                      color: 'B60205',
+                    });
+                    core.info(`Created missing '${LABEL}' label.`);
+                  } catch (createLabelErr) {
+                    core.warning(`Could not create '${LABEL}' label: ${createLabelErr.message}`);
+                  }
+                } else {
+                  core.warning(`Could not look up '${LABEL}' label: ${getLabelErr.message}`);
+                }
+              }
+
               // Find an existing OPEN issue carrying the ingestion-alert label so repeated
               // failures comment on one thread instead of spamming new issues.
               const existing = await github.rest.issues.listForRepo({
@@ -70,8 +97,22 @@ jobs:
                 per_page: 1,
               });
 
-              if (existing.data.length > 0) {
-                const issueNumber = existing.data[0].number;
+              // Fallback dedup by title: if the label search returns nothing (e.g. the label
+              // was just created, or a prior issue lost its label), search open issues by
+              // title so we still comment on an existing thread instead of opening a duplicate.
+              let dedupNumber = existing.data.length > 0 ? existing.data[0].number : null;
+              if (dedupNumber === null) {
+                const byTitle = await github.rest.search.issuesAndPullRequests({
+                  q: `repo:${context.repo.owner}/${context.repo.repo} is:issue is:open "Ingestion gap detected" in:title`,
+                  per_page: 1,
+                });
+                if (byTitle.data.total_count > 0) {
+                  dedupNumber = byTitle.data.items[0].number;
+                }
+              }
+
+              if (dedupNumber !== null) {
+                const issueNumber = dedupNumber;
                 await github.rest.issues.createComment({
                   owner: context.repo.owner,
                   repo: context.repo.repo,

--- a/scripts/launchd/com.aipowerranking.ingestion-gap.plist
+++ b/scripts/launchd/com.aipowerranking.ingestion-gap.plist
@@ -7,9 +7,10 @@
        the 09:00 UTC server cron window. This is the awake-only complement to the
        always-on GitHub-issue alert.
 
-  EDIT ME: If your clone of this repo lives somewhere other than
-  /Users/masa/Projects/aipowerranking, update the absolute path in ProgramArguments
-  (and the StandardOutPath/StandardErrorPath if you prefer different log locations).
+  PORTABILITY: ProgramArguments uses the %%REPO_ROOT%% placeholder token. The install
+  command in scripts/notify/README.md substitutes it with your repo root at copy time
+  (sed "s|%%REPO_ROOT%%|$(pwd)|g"), so this template stays clone-location agnostic.
+  Adjust StandardOutPath/StandardErrorPath too if you prefer different log locations.
 
   Install/test/uninstall steps are in scripts/notify/README.md.
 -->
@@ -21,7 +22,7 @@
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
-        <string>/Users/masa/Projects/aipowerranking/scripts/notify/ingestion-gap-notify.sh</string>
+        <string>%%REPO_ROOT%%/scripts/notify/ingestion-gap-notify.sh</string>
     </array>
 
     <!-- Daily at 09:15 local time — just after the server-side 09:00 UTC cron window. -->

--- a/scripts/launchd/com.aipowerranking.ingestion-gap.plist
+++ b/scripts/launchd/com.aipowerranking.ingestion-gap.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  launchd template for the local macOS ingestion-gap notifier.
+
+  Why: Runs the desktop notifier daily so a silent scraper surfaces locally, just after
+       the 09:00 UTC server cron window. This is the awake-only complement to the
+       always-on GitHub-issue alert.
+
+  EDIT ME: If your clone of this repo lives somewhere other than
+  /Users/masa/Projects/aipowerranking, update the absolute path in ProgramArguments
+  (and the StandardOutPath/StandardErrorPath if you prefer different log locations).
+
+  Install/test/uninstall steps are in scripts/notify/README.md.
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.aipowerranking.ingestion-gap</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/masa/Projects/aipowerranking/scripts/notify/ingestion-gap-notify.sh</string>
+    </array>
+
+    <!-- Daily at 09:15 local time — just after the server-side 09:00 UTC cron window. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>15</integer>
+    </dict>
+
+    <!-- Do not run on load; only on the scheduled interval (or manual `launchctl start`). -->
+    <key>RunAtLoad</key>
+    <false/>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/aipr-ingestion-gap.out</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/aipr-ingestion-gap.err</string>
+</dict>
+</plist>

--- a/scripts/notify/README.md
+++ b/scripts/notify/README.md
@@ -49,13 +49,15 @@ With a healthy DB this logs an `OK:` line and shows no notification. Logs are wr
 
 ### Install the launchd job
 
+Run from the repo root. The `sed` substitutes the `%%REPO_ROOT%%` placeholder in the
+plist template with your current repo path at copy time, so the installed agent points
+at this clone regardless of where it lives:
+
 ```bash
-cp scripts/launchd/com.aipowerranking.ingestion-gap.plist ~/Library/LaunchAgents/
+sed "s|%%REPO_ROOT%%|$(pwd)|g" scripts/launchd/com.aipowerranking.ingestion-gap.plist \
+  > ~/Library/LaunchAgents/com.aipowerranking.ingestion-gap.plist
 launchctl load ~/Library/LaunchAgents/com.aipowerranking.ingestion-gap.plist
 ```
-
-> If your clone lives somewhere other than `/Users/masa/Projects/aipowerranking`, edit
-> the absolute path in the plist's `ProgramArguments` before copying it.
 
 It runs daily at **09:15 local time** — just after the 09:00 UTC server cron window.
 
@@ -65,7 +67,16 @@ It runs daily at **09:15 local time** — just after the 09:00 UTC server cron w
 launchctl start com.aipowerranking.ingestion-gap
 ```
 
-Then inspect output:
+Then inspect output. There are **two distinct log destinations** — check both when
+debugging a missed notification:
+
+- **`tmp/aipr-ingestion-gap.log`** (repo-relative, gitignored) — the script's own
+  `log()` output: the timestamped `OK:`/`ALERT:` lines and the captured check output.
+  Falls back to `/tmp/aipr-ingestion-gap.log` if the repo `tmp/` dir can't be created.
+- **`/tmp/aipr-ingestion-gap.out`** and **`/tmp/aipr-ingestion-gap.err`** — launchd's
+  captured stdout/stderr for the agent process (set via `StandardOutPath` /
+  `StandardErrorPath` in the plist). Look here for launchd-level failures such as a bad
+  `ProgramArguments` path or the agent never starting.
 
 ```bash
 cat /tmp/aipr-ingestion-gap.out /tmp/aipr-ingestion-gap.err

--- a/scripts/notify/README.md
+++ b/scripts/notify/README.md
@@ -1,0 +1,87 @@
+# Ingestion-gap alerting
+
+Two independent, webhook-free channels warn you when the daily scraper goes silent
+(no row in `automated_ingestion_runs` for 25h+). Both reuse the same gating script,
+`scripts/check-ingestion-gap.mjs`.
+
+| Channel | Where it runs | Always on? | Secrets needed |
+| --- | --- | --- | --- |
+| GitHub failed-workflow email + auto-opened issue | GitHub Actions (`.github/workflows/cron-gap-detector.yml`) | Yes (server-side) | None — uses the built-in `GITHUB_TOKEN` |
+| macOS desktop notification | Your Mac, via `launchd` | Only while the Mac is awake/online | None — reads `.env.local` locally |
+
+The GitHub channel is the **always-on** baseline. The macOS notifier is a louder,
+local complement that only fires while your machine is awake.
+
+## GitHub channel (no setup required)
+
+On a detected gap, `cron-gap-detector.yml`:
+
+1. Fails the workflow red, which triggers GitHub's built-in failed-workflow email.
+2. Opens a de-duplicated tracking issue (or comments on the existing open one) labeled
+   `ingestion-alert`, assigned to `bobmatnyc`.
+
+No secrets are required for the issue alert — it uses the default `GITHUB_TOKEN` via
+`actions/github-script`. The assignee (`bobmatnyc`) is editable directly in the workflow
+(`ASSIGNEE` constant in the `Open or update ingestion-alert issue` step).
+
+> Note: the issue is **not** auto-closed on recovery yet — close it manually once
+> ingestion resumes. (Auto-close-on-recovery is flagged as a future enhancement in the
+> workflow.)
+
+## macOS notifier (launchd)
+
+### Prerequisites
+
+- A `.env.local` at the repo root containing `DATABASE_URL` (the same value the GitHub
+  job pulls from `secrets.DATABASE_URL`).
+- Optional: [`terminal-notifier`](https://github.com/julienXX/terminal-notifier)
+  (`brew install terminal-notifier`) for richer notifications. Without it, the script
+  falls back to the built-in `osascript` notification.
+
+### Test the script directly first
+
+```bash
+bash scripts/notify/ingestion-gap-notify.sh
+```
+
+With a healthy DB this logs an `OK:` line and shows no notification. Logs are written to
+`tmp/aipr-ingestion-gap.log` (gitignored), falling back to `/tmp/aipr-ingestion-gap.log`.
+
+### Install the launchd job
+
+```bash
+cp scripts/launchd/com.aipowerranking.ingestion-gap.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.aipowerranking.ingestion-gap.plist
+```
+
+> If your clone lives somewhere other than `/Users/masa/Projects/aipowerranking`, edit
+> the absolute path in the plist's `ProgramArguments` before copying it.
+
+It runs daily at **09:15 local time** — just after the 09:00 UTC server cron window.
+
+### Trigger it immediately (smoke test)
+
+```bash
+launchctl start com.aipowerranking.ingestion-gap
+```
+
+Then inspect output:
+
+```bash
+cat /tmp/aipr-ingestion-gap.out /tmp/aipr-ingestion-gap.err
+cat tmp/aipr-ingestion-gap.log
+```
+
+### Uninstall
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.aipowerranking.ingestion-gap.plist
+rm ~/Library/LaunchAgents/com.aipowerranking.ingestion-gap.plist
+```
+
+### Limitations
+
+The launchd job only fires while the Mac is awake and online. If the machine is asleep at
+09:15, macOS may run it shortly after wake — but a powered-off machine misses the window
+entirely. That is by design: the GitHub-issue alert is the always-on, server-side safety
+net, and this is the local convenience layer on top.

--- a/scripts/notify/ingestion-gap-notify.sh
+++ b/scripts/notify/ingestion-gap-notify.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+#
+# Why: Server-side GitHub alerts only reach you by email; this gives the maintainer a
+#   loud, local macOS notification when the daily scraper goes silent — the same
+#   25h ingestion-gap signal, surfaced on the desktop. It is the awake-only local
+#   complement to the always-on GitHub-issue alert.
+# What: Loads DATABASE_URL from .env.local (same env the GitHub job sets), runs
+#   scripts/check-ingestion-gap.mjs, and on a NON-zero exit fires a macOS
+#   notification (terminal-notifier if present, else osascript). Zero exit is quiet.
+# Test: With a healthy DB, run `bash scripts/notify/ingestion-gap-notify.sh` — it logs
+#   an OK line and shows no notification. To force the alert path, point DATABASE_URL
+#   at a DB with no recent automated_ingestion_runs rows (or temporarily lower the
+#   threshold in check-ingestion-gap.mjs) and re-run — a notification should appear and
+#   the log should contain an ALERT line.
+
+set -euo pipefail
+
+# Resolve the repo root from this script's location so the job is portable regardless
+# of where launchd invokes it from. Script lives at <repo>/scripts/notify/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Log to the gitignored repo tmp/ dir; fall back to /tmp if it cannot be created.
+LOG_DIR="${REPO_ROOT}/tmp"
+if ! mkdir -p "${LOG_DIR}" 2>/dev/null; then
+  LOG_DIR="/tmp"
+fi
+LOG_FILE="${LOG_DIR}/aipr-ingestion-gap.log"
+
+log() {
+  # Timestamped line to both stdout (captured by launchd StandardOutPath) and the log file.
+  printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$1" | tee -a "${LOG_FILE}"
+}
+
+# Load .env.local if present so DATABASE_URL is available, mirroring the GitHub job env.
+# `set -a` exports every var assigned while sourcing.
+if [[ -f "${REPO_ROOT}/.env.local" ]]; then
+  set -a
+  # shellcheck disable=SC1091
+  source "${REPO_ROOT}/.env.local"
+  set +a
+fi
+
+notify() {
+  # Fire a macOS notification, preferring terminal-notifier; fall back to osascript.
+  local title="🚨 AIPR ingestion stalled"
+  local message="No AIPR ingestion run in 25h+ — daily scraper may be down"
+  if command -v terminal-notifier >/dev/null 2>&1; then
+    terminal-notifier -title "${title}" -message "${message}" -sound Sosumi || true
+  else
+    osascript -e "display notification \"${message}\" with title \"${title}\" sound name \"Sosumi\"" || true
+  fi
+}
+
+# Run the gating check without tripping `set -e`; we want to branch on its exit code.
+set +e
+CHECK_OUTPUT="$(node scripts/check-ingestion-gap.mjs 2>&1)"
+EXIT_CODE=$?
+set -e
+
+# Echo the check's own output into the log for post-mortem context.
+if [[ -n "${CHECK_OUTPUT}" ]]; then
+  printf '%s\n' "${CHECK_OUTPUT}" | tee -a "${LOG_FILE}"
+fi
+
+if [[ "${EXIT_CODE}" -ne 0 ]]; then
+  log "ALERT: ingestion gap check exited ${EXIT_CODE} — firing macOS notification"
+  notify
+  exit "${EXIT_CODE}"
+fi
+
+log "OK: ingestion gap check passed (exit 0); no notification"
+exit 0

--- a/scripts/notify/ingestion-gap-notify.sh
+++ b/scripts/notify/ingestion-gap-notify.sh
@@ -49,7 +49,12 @@ notify() {
   if command -v terminal-notifier >/dev/null 2>&1; then
     terminal-notifier -title "${title}" -message "${message}" -sound Sosumi || true
   else
-    osascript -e "display notification \"${message}\" with title \"${title}\" sound name \"Sosumi\"" || true
+    # Sanitize before interpolating into the AppleScript string: escape backslashes
+    # first, then double-quotes, so the literals can't break out of or inject into the
+    # osascript expression (defense-in-depth even though these are static literals today).
+    local safe_msg=${message//\\/\\\\}; safe_msg=${safe_msg//\"/\\\"}
+    local safe_title=${title//\\/\\\\}; safe_title=${safe_title//\"/\\\"}
+    osascript -e "display notification \"${safe_msg}\" with title \"${safe_title}\" sound name \"Sosumi\"" || true
   fi
 }
 


### PR DESCRIPTION
## Summary
Implements two-channel webhook-free alerting for the daily ingestion-gap detector:

1. **GitHub Auto-Issue Channel**: When gaps are detected, automatically opens/updates a GitHub issue assigned to @bobmatnyc via GITHUB_TOKEN (no secrets in code)
2. **macOS Local Notifier Channel**: Sends push notifications via launchd scheduled job with setup documentation

No production route/app code changed. Alerts are ops-focused for the daily cron job.

## Files Changed
- `.github/workflows/cron-gap-detector.yml` - Updated cron job to trigger alerting
- `scripts/notify/ingestion-gap-notify.sh` - Core notification script (GitHub issue + macOS notifier)
- `scripts/notify/README.md` - Setup and usage documentation
- `scripts/launchd/com.aipowerranking.ingestion-gap.plist` - macOS launchd configuration

Closes #69