### PR TITLE
fix(ops): commit vercel.json so GitHub deploys register cron schedules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,6 +102,8 @@ test-clerk-keys.js
 
 # Temporary files in root
 /*.json
+# vercel.json must be tracked so GitHub deploys register cron schedules (see issue #71)
+!vercel.json
 !package.json
 !package-lock.json
 !tsconfig.json

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "crons": [
+    {
+      "path": "/api/cron/daily-news",
+      "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/monthly-summary",
+      "schedule": "0 8 1 * *"
+    }
+  ]
+}


### PR DESCRIPTION
## The Problem: Recurring 12-Day Outage Cycle

vercel.json (containing the daily-news ingestion cron schedule) was gitignored via `.gitignore /*.json`, meaning:

1. GitHub's auto-deploy on every merge to main skips vercel.json
2. Vercel deploys receive **crons: []** (empty schedule)
3. The daily ingestion cron binding is **silently unbound** on each auto-deploy
4. ~12 days later: manual fix is merged, cron re-registers
5. Hours later: another PR merges to main, triggers auto-deploy, unbinds cron again
6. Back to no ingestion for another ~12 days

This PR happened after PR #70 merged on Jun-15 — that merge triggered an auto-deploy that clobbered our manual fix **33 minutes later**.

## The Fix

Commit vercel.json to git (crons-only, byte-identical to production) with a `.gitignore` negation:

```gitignore
*.json
!vercel.json  # Always commit cron config
```

Now every GitHub auto-deploy registers the crons durably. No more silent unbinding.

## Details

- File is crons-only configuration
- Byte-identical to live production config
- Safe to commit (no secrets, no environment-specific data)
- Negation pattern ensures it always commits

Closes #71