### PR TITLE
perf(ingestion): reduce Tavily cost (supplementary query 2->1)

### DIFF
--- a/lib/services/automated-ingestion.service.ts
+++ b/lib/services/automated-ingestion.service.ts
@@ -514,6 +514,14 @@ export class AutomatedIngestionService {
         // Check if article already has content (from Tavily Search)
         const tavilyContent = (article as TavilySearchResult).content;
 
+        // Cost reduction: when the Tavily Search result already carries a
+        // content snippet at/above the sufficiency threshold (> 100 chars — the
+        // SAME bar reused across the extraction chain, see fetchArticleContent),
+        // reuse that snippet and SKIP the per-article Tavily Extract call below.
+        // Tavily Extract is only invoked in the `else` fallback (when the
+        // snippet is missing or below threshold), preserving the original
+        // Tavily Extract → Jina → Basic HTML fallback chain and downstream
+        // quality gates unchanged.
         if (tavilyContent && tavilyContent.length > 100) {
           // Use Tavily's pre-fetched content from search results
           extractionStats.usedTavilySearchContent++;

--- a/lib/services/tavily-search.service.ts
+++ b/lib/services/tavily-search.service.ts
@@ -262,12 +262,14 @@ AI developer tools announcement OR agentic coding 2026`.replace(/\s+/g, ' ').tri
       'Claude Anthropic developer tools API update',
     ];
 
-    // Return 2 queries based on day of week
+    // Cost reduction: issue ONE rotated supplementary query per run instead of
+    // two. This trims ~1 Tavily search credit per ingestion run while keeping
+    // daily coverage variety — the chosen query still advances by one slot each
+    // day (startIndex = dayOfWeek), so across a week the full topic list is
+    // still swept. The primary discovery query is unchanged. Reverting is a
+    // one-line change (re-add the (startIndex + 1) entry below).
     const startIndex = dayOfWeek % allQueries.length;
-    return [
-      allQueries[startIndex],
-      allQueries[(startIndex + 1) % allQueries.length],
-    ];
+    return [allQueries[startIndex]];
   }
 
   /**


### PR DESCRIPTION
Cuts supplementary Tavily search queries from 2 to 1 per run (keeps day-rotation so coverage still varies; primary query unchanged) for ~1 fewer Tavily credit/run. Also documents the already-present skip-Extract-when-search-snippet->100-chars optimization (no behavior change). Follow-up to the provider-fallback PR #73.