### PR TITLE
feat(rankings): monthly cron to regenerate rankings + public "as of" staleness marker

### DIFF
--- a/app/api/cron/regenerate-rankings/route.ts
+++ b/app/api/cron/regenerate-rankings/route.ts
@@ -1,0 +1,172 @@
+/**
+ * Cron API: Monthly Ranking Regeneration
+ *
+ * GET /api/cron/regenerate-rankings
+ * - Runs on the 1st of the month at 09:00 UTC (configured in vercel.json)
+ * - Recomputes v7.6 rankings for the current period and persists a new current
+ *   snapshot (previous snapshot demoted, new row `is_current = true`)
+ * - Requires CRON_SECRET authentication via Bearer token (same as sibling crons)
+ * - Idempotent per period; concurrent/duplicate runs for the same period return 409
+ */
+
+import { NextResponse } from "next/server";
+import { loggers } from "@/lib/logger";
+import {
+  RankingGenerationInProgressError,
+  regenerateRankings,
+} from "@/lib/services/ranking-generation.service";
+
+/**
+ * Send a failure alert via webhook when the cron route encounters an error.
+ *
+ * Uses ALERT_WEBHOOK_URL env var (e.g. a Slack incoming webhook or similar).
+ * Silently no-ops if the env var is not set.
+ */
+async function sendCronAlert(
+  route: string,
+  errorMessage: string,
+  details: Record<string, unknown>
+): Promise<void> {
+  const webhookUrl = process.env["ALERT_WEBHOOK_URL"];
+  if (!webhookUrl) return;
+
+  try {
+    await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        text: `[CRON FAILURE] ${route}`,
+        error: errorMessage,
+        ...details,
+        timestamp: new Date().toISOString(),
+      }),
+    });
+  } catch {
+    // Never throw from the alert path — logging is sufficient fallback
+    loggers.api.error("Cron: Failed to send alert webhook", { route });
+  }
+}
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 300; // 5 minutes — matches sibling cron routes
+
+/**
+ * Verify if request is authorized for cron execution.
+ *
+ * Uses ONLY the Bearer token check per Vercel's official cron documentation.
+ * Vercel's cron scheduler automatically sends `Authorization: Bearer <CRON_SECRET>`.
+ */
+function isAuthorizedCronRequest(request: Request): boolean {
+  const authHeader = request.headers.get("authorization");
+  const cronSecret = process.env["CRON_SECRET"];
+
+  if (!cronSecret) {
+    loggers.api.error("Cron: CRON_SECRET environment variable not configured");
+    return false;
+  }
+
+  if (authHeader === `Bearer ${cronSecret}`) {
+    loggers.api.info("Cron: Authorized via Bearer token");
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * GET /api/cron/regenerate-rankings
+ * Vercel Cron endpoint for monthly ranking regeneration.
+ */
+export async function GET(request: Request) {
+  const startTime = Date.now();
+
+  try {
+    // 1. Verify cron authentication
+    if (!isAuthorizedCronRequest(request)) {
+      loggers.api.warn("Unauthorized cron request", {
+        hasAuthHeader: !!request.headers.get("authorization"),
+        userAgent: request.headers.get("user-agent"),
+        endpoint: "/api/cron/regenerate-rankings",
+      });
+
+      await sendCronAlert(
+        "/api/cron/regenerate-rankings",
+        "401 Unauthorized — CRON_SECRET mismatch or not set",
+        {
+          hasAuthHeader: !!request.headers.get("authorization"),
+          impact: "Monthly ranking regeneration is not running — the published list will go stale",
+        }
+      );
+
+      return NextResponse.json({ success: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    loggers.api.info("Cron: Starting ranking regeneration", {
+      triggerDate: new Date().toISOString(),
+    });
+
+    // 2. Regenerate rankings (idempotent per period, guarded against concurrent runs)
+    const result = await regenerateRankings();
+
+    const duration = Date.now() - startTime;
+    loggers.api.info("Cron: Ranking regeneration complete", {
+      period: result.period,
+      algorithmVersion: result.algorithmVersion,
+      toolCount: result.toolCount,
+      publishedAt: result.publishedAt,
+      durationMs: duration,
+    });
+
+    // 3. Return JSON summary
+    return NextResponse.json(
+      {
+        success: true,
+        message: `Rankings regenerated for ${result.period}`,
+        period: result.period,
+        algorithm_version: result.algorithmVersion,
+        tool_count: result.toolCount,
+        published_at: result.publishedAt,
+        top_movers: result.topMovers,
+        durationMs: duration,
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    const duration = Date.now() - startTime;
+
+    // Concurrent/duplicate run for the same period — not a failure, just declined.
+    if (error instanceof RankingGenerationInProgressError) {
+      loggers.api.warn("Cron: Ranking regeneration already in progress", {
+        period: error.period,
+        durationMs: duration,
+      });
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Ranking regeneration already in progress for this period",
+          period: error.period,
+        },
+        { status: 409 }
+      );
+    }
+
+    const errorMessage = error instanceof Error ? error.message : "Unknown error";
+    loggers.api.error("Cron: Failed to regenerate rankings", {
+      error: errorMessage,
+      stack: error instanceof Error ? error.stack : undefined,
+      durationMs: duration,
+    });
+
+    await sendCronAlert("/api/cron/regenerate-rankings", errorMessage, {
+      durationMs: duration,
+      stack: error instanceof Error ? error.stack?.split("\n").slice(0, 5).join(" | ") : undefined,
+      impact: "Monthly ranking regeneration failed — the published rankings may be stale",
+    });
+
+    return NextResponse.json(
+      { success: false, error: "Failed to regenerate rankings", details: errorMessage },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/rankings/route.ts
+++ b/app/api/rankings/route.ts
@@ -188,6 +188,11 @@ export async function GET(): Promise<NextResponse> {
     return cachedJsonResponse(
       {
         rankings: validRankings,
+        // published_at reflects when the current snapshot was actually published,
+        // so the public UI can surface an honest "Rankings as of <date>" marker
+        // (falls back to created_at for legacy rows that predate published_at).
+        published_at: (currentRankings.published_at ?? currentRankings.created_at).toISOString(),
+        period: currentRankings.period,
         algorithm: {
           version: currentRankings.algorithm_version || "v1.0",
           name: "Database Rankings",

--- a/components/ranking/rankings-grid.tsx
+++ b/components/ranking/rankings-grid.tsx
@@ -73,6 +73,9 @@ function RankingsGridContent({
   const [loading, setLoading] = useState(initialRankings.length === 0);
   const [viewMode, setViewMode] = useState<"grid" | "list">("grid");
   const [lastUpdateDate, setLastUpdateDate] = useState<string>("");
+  // Honest "Rankings as of <date>" marker sourced from the current snapshot's
+  // published_at, so a frozen snapshot is never presented as fresh silently.
+  const [publishedDate, setPublishedDate] = useState<string>("");
   const [totalTools, setTotalTools] = useState<number>(0);
   const [categoriesCount, setCategoriesCount] = useState<number>(0);
   const [avgScore, setAvgScore] = useState<number>(0);
@@ -125,6 +128,15 @@ function RankingsGridContent({
           });
           setLastUpdateDate(formattedDate);
         }
+        if (data.published_at) {
+          setPublishedDate(
+            new Date(data.published_at).toLocaleDateString(lang, {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })
+          );
+        }
       }
     } catch {
       // Silently fail, will use fallback
@@ -161,6 +173,17 @@ function RankingsGridContent({
 
           const avgScoreValue = data.rankings.reduce((acc: number, r: RankingData) => acc + (r.scores?.overall || 0), 0) / data.rankings.length;
           setAvgScore(avgScoreValue);
+        }
+
+        // Set the "Rankings as of" marker from the snapshot's published_at
+        if (data.published_at) {
+          setPublishedDate(
+            new Date(data.published_at).toLocaleDateString(lang, {
+              month: "long",
+              day: "numeric",
+              year: "numeric",
+            })
+          );
         }
 
         // Set last update date from algorithm date
@@ -259,6 +282,11 @@ function RankingsGridContent({
       <div className="mb-8">
         <h1 className="text-4xl font-bold mb-2">{dict.common.appName}</h1>
         <p className="text-muted-foreground text-lg">{dict.rankings.subtitle}</p>
+        {publishedDate && (
+          <p className="text-sm text-muted-foreground mt-2">
+            {dict.rankings.asOf.replace("{date}", publishedDate)}
+          </p>
+        )}
       </div>
 
       {/* Stats Cards - Optimized for T-031 & T-040 CLS fix */}

--- a/i18n/dictionaries/de.json
+++ b/i18n/dictionaries/de.json
@@ -187,6 +187,7 @@
     "aboutDescription": "Diese Grafik zeigt, wie KI-Tools im Laufe der Zeit in die Top-10-Rankings ein- und ausgestiegen sind. Tools weiter oben in der Grafik (näher an #1) schneiden besser ab."
   },
   "rankings": {
+    "asOf": "Rankings vom {date}",
     "title": "KI Power Rankings",
     "subtitle": "Umfassende Rankings von KI-Coding-Tools mit Algorithmus v7.6",
     "stats": {

--- a/i18n/dictionaries/en.json
+++ b/i18n/dictionaries/en.json
@@ -193,6 +193,7 @@
     "copyright": "© 2025 AI Power Ranking. All rights reserved."
   },
   "rankings": {
+    "asOf": "Rankings as of {date}",
     "title": "AI Power Ranking",
     "subtitle": "Comprehensive rankings of AI coding tools using Algorithm v7.6 - Market-validated scoring",
     "stats": {

--- a/i18n/dictionaries/es.json
+++ b/i18n/dictionaries/es.json
@@ -193,6 +193,7 @@
     "copyright": "© 2025 AI Power Ranking. Todos los derechos reservados."
   },
   "rankings": {
+    "asOf": "Clasificación al {date}",
     "title": "AI Power Ranking",
     "subtitle": "Clasificaciones exhaustivas de herramientas de codificación IA usando Algorithm v7.6",
     "stats": {

--- a/i18n/dictionaries/fr.json
+++ b/i18n/dictionaries/fr.json
@@ -193,6 +193,7 @@
     "copyright": "© 2025 Classement IA Power. Tous droits réservés."
   },
   "rankings": {
+    "asOf": "Classement au {date}",
     "title": "Classement IA Power",
     "subtitle": "Classements complets des outils de codage IA utilisant l'Algorithme v7.6 - Scoring validé par le marché",
     "stats": {

--- a/i18n/dictionaries/hr.json
+++ b/i18n/dictionaries/hr.json
@@ -193,6 +193,7 @@
     "copyright": "© 2025 AI Power Rankings. Sva prava zadržana."
   },
   "rankings": {
+    "asOf": "Poredak od {date}",
     "title": "AI Power Rankings",
     "subtitle": "Sveobuhvatna rangiranja AI alata za kodiranje s algoritmom v7.6",
     "stats": {

--- a/i18n/dictionaries/it.json
+++ b/i18n/dictionaries/it.json
@@ -193,6 +193,7 @@
     "copyright": "© 2025 AI Power Ranking. Tutti i diritti riservati."
   },
   "rankings": {
+    "asOf": "Classifica al {date}",
     "title": "Classifiche AI Power",
     "subtitle": "Classifiche complete di strumenti di codifica AI usando l'Algoritmo v7.6 - Scoring validato dal mercato",
     "stats": {

--- a/i18n/dictionaries/ja.json
+++ b/i18n/dictionaries/ja.json
@@ -393,6 +393,7 @@
     "copyright": "© 2025 AI Power Ranking. All rights reserved."
   },
   "rankings": {
+    "asOf": "{date} 時点のランキング",
     "title": "AI パワーランキング",
     "subtitle": "アルゴリズム v7.6を使用したAIコーディングツールの包括的ランキング",
     "stats": {

--- a/i18n/dictionaries/ko.json
+++ b/i18n/dictionaries/ko.json
@@ -187,6 +187,7 @@
     "copyright": "© 2025 AI Power Ranking. 모든 권리 보유."
   },
   "rankings": {
+    "asOf": "{date} 기준 순위",
     "title": "AI 파워 랭킹",
     "subtitle": "알고리즘 v7.0을 사용한 AI 코딩 도구의 종합적인 랭킹",
     "stats": {

--- a/i18n/dictionaries/uk.json
+++ b/i18n/dictionaries/uk.json
@@ -193,6 +193,7 @@
     "copyright": "© 2025 AI Power Rankings. Всі права захищені."
   },
   "rankings": {
+    "asOf": "Рейтинг станом на {date}",
     "title": "AI Power Rankings",
     "subtitle": "Комплексні рейтинги AI інструментів кодування з алгоритмом v7.6",
     "stats": {

--- a/i18n/dictionaries/zh.json
+++ b/i18n/dictionaries/zh.json
@@ -442,6 +442,7 @@
     }
   },
   "rankings": {
+    "asOf": "截至 {date} 的排名",
     "title": "AI 实力排行榜",
     "subtitle": "使用算法v7.6的AI编码工具综合排名",
     "stats": {

--- a/i18n/expected-structure.ts
+++ b/i18n/expected-structure.ts
@@ -182,6 +182,7 @@ export const EXPECTED_DICTIONARY_STRUCTURE = {
     copyright: "",
   },
   rankings: {
+    asOf: "",
     title: "",
     subtitle: "",
     stats: {

--- a/lib/services/ranking-generation.service.test.ts
+++ b/lib/services/ranking-generation.service.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPreviousRankMap,
+  calculateTier,
+  computeRankings,
+  RankingGenerationInProgressError,
+  type RankingEntry,
+  type RankingPersistencePort,
+  type RankingSourceTool,
+  RANKING_ALGORITHM_VERSION,
+  regenerateRankings,
+  toPeriod,
+} from "./ranking-generation.service";
+
+function makeTool(id: string, name: string, users: number): RankingSourceTool {
+  return {
+    id,
+    name,
+    slug: name.toLowerCase().replace(/\s+/g, "-"),
+    category: "code-editor",
+    status: "active",
+    data: { metrics: { users, github_stars: users / 10 } },
+  };
+}
+
+const sampleTools = [
+  makeTool("t1", "Alpha", 1_000_000),
+  makeTool("t2", "Bravo", 500_000),
+  makeTool("t3", "Charlie", 10_000),
+];
+
+/** In-memory persistence adapter capturing the saved snapshot. */
+function fakePersistence(
+  current: { data: unknown } | null = null
+): RankingPersistencePort & { saved?: { period: string; algorithmVersion: string; data: RankingEntry[] } } {
+  const port: RankingPersistencePort & {
+    saved?: { period: string; algorithmVersion: string; data: RankingEntry[] };
+  } = {
+    loadActiveTools: async () => sampleTools,
+    loadCurrentRankings: async () => current,
+    saveSnapshot: async ({ period, algorithmVersion, data }) => {
+      port.saved = { period, algorithmVersion, data };
+    },
+  };
+  return port;
+}
+
+describe("ranking-generation.service", () => {
+  describe("toPeriod", () => {
+    it("formats a UTC date as YYYY-MM", () => {
+      expect(toPeriod(new Date("2026-07-01T00:00:00Z"))).toBe("2026-07");
+      expect(toPeriod(new Date("2026-01-31T23:59:59Z"))).toBe("2026-01");
+    });
+  });
+
+  describe("calculateTier", () => {
+    it("assigns tiers by rank band", () => {
+      expect(calculateTier(1)).toBe("S");
+      expect(calculateTier(6)).toBe("A");
+      expect(calculateTier(16)).toBe("B");
+      expect(calculateTier(31)).toBe("C");
+      expect(calculateTier(46)).toBe("D");
+    });
+  });
+
+  describe("buildPreviousRankMap", () => {
+    it("reads a bare array snapshot", () => {
+      const map = buildPreviousRankMap([{ tool_id: "t1", rank: 3 }, { tool_id: "t2", rank: 1 }]);
+      expect(map.get("t1")).toBe(3);
+      expect(map.get("t2")).toBe(1);
+    });
+
+    it("reads a wrapped { rankings: [] } snapshot and tolerates null", () => {
+      expect(buildPreviousRankMap({ rankings: [{ id: "t9", position: 4 }] }).get("t9")).toBe(4);
+      expect(buildPreviousRankMap(null).size).toBe(0);
+    });
+  });
+
+  describe("computeRankings", () => {
+    it("scores, sorts descending, and assigns sequential ranks + tiers", () => {
+      const result = computeRankings(sampleTools, new Map());
+
+      expect(result).toHaveLength(3);
+      expect(result.map((r) => r.rank)).toEqual([1, 2, 3]);
+      for (let i = 0; i < result.length - 1; i++) {
+        expect(result[i]!.score).toBeGreaterThanOrEqual(result[i + 1]!.score);
+        expect(result[i]!.tier).toBe(calculateTier(result[i]!.rank));
+        expect(Object.keys(result[i]!.factor_scores).length).toBeGreaterThan(0);
+      }
+    });
+
+    it("marks all tools as new when there is no prior snapshot", () => {
+      const result = computeRankings(sampleTools, new Map());
+      for (const entry of result) {
+        expect(entry.movement.previous_position).toBeNull();
+        expect(entry.movement.change).toBe(0);
+        expect(entry.movement.direction).toBe("same");
+      }
+    });
+
+    it("computes upward movement relative to a prior rank", () => {
+      const first = computeRankings(sampleTools, new Map());
+      const top = first[0]!;
+      // Pretend the current #1 was previously ranked 3 places lower.
+      const prev = new Map([[top.tool_id, top.rank + 3]]);
+
+      const again = computeRankings(sampleTools, prev);
+      const moved = again.find((r) => r.tool_id === top.tool_id)!;
+
+      expect(moved.movement.previous_position).toBe(top.rank + 3);
+      expect(moved.movement.change).toBe(3);
+      expect(moved.movement.direction).toBe("up");
+    });
+  });
+
+  describe("regenerateRankings", () => {
+    it("loads, computes, persists a current snapshot, and returns a summary", async () => {
+      const persistence = fakePersistence();
+      const now = () => new Date("2026-07-01T09:00:00Z");
+
+      const result = await regenerateRankings({ persistence, now });
+
+      expect(result.period).toBe("2026-07");
+      expect(result.algorithmVersion).toBe(RANKING_ALGORITHM_VERSION);
+      expect(result.toolCount).toBe(3);
+      expect(result.publishedAt).toBe("2026-07-01T09:00:00.000Z");
+
+      expect(persistence.saved).toBeDefined();
+      expect(persistence.saved!.period).toBe("2026-07");
+      expect(persistence.saved!.algorithmVersion).toBe(RANKING_ALGORITHM_VERSION);
+      expect(persistence.saved!.data).toHaveLength(3);
+    });
+
+    it("honors an explicit period override", async () => {
+      const persistence = fakePersistence();
+      const result = await regenerateRankings({ persistence, period: "2025-12" });
+      expect(result.period).toBe("2025-12");
+      expect(persistence.saved!.period).toBe("2025-12");
+    });
+
+    it("rejects a concurrent run for the same period", async () => {
+      let releaseLoad: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        releaseLoad = resolve;
+      });
+
+      const persistence: RankingPersistencePort = {
+        loadActiveTools: async () => {
+          await gate; // hold the first run open
+          return sampleTools;
+        },
+        loadCurrentRankings: async () => null,
+        saveSnapshot: async () => {},
+      };
+
+      const opts = { persistence, period: "2026-07" };
+      const firstRun = regenerateRankings(opts);
+      // Second run for the same period must be rejected while the first is in flight.
+      await expect(regenerateRankings(opts)).rejects.toBeInstanceOf(
+        RankingGenerationInProgressError
+      );
+
+      releaseLoad();
+      await expect(firstRun).resolves.toMatchObject({ period: "2026-07" });
+    });
+
+    it("surfaces the prior snapshot as movement context", async () => {
+      const seedRun = fakePersistence();
+      await regenerateRankings({ persistence: seedRun, period: "2026-06" });
+      const prior = seedRun.saved!.data;
+      const topId = prior.find((r) => r.rank === 1)!.tool_id;
+
+      const persistence = fakePersistence({ data: prior.map((r) => ({ tool_id: r.tool_id, rank: r.rank + (r.tool_id === topId ? 2 : 0) })) });
+      const spy = vi.spyOn(persistence, "loadCurrentRankings");
+      await regenerateRankings({ persistence, period: "2026-07" });
+
+      expect(spy).toHaveBeenCalledOnce();
+      const movedTop = persistence.saved!.data.find((r) => r.tool_id === topId)!;
+      expect(movedTop.movement.previous_position).toBe(movedTop.rank + 2);
+    });
+  });
+});

--- a/lib/services/ranking-generation.service.ts
+++ b/lib/services/ranking-generation.service.ts
@@ -1,0 +1,298 @@
+/**
+ * Ranking Generation Service
+ *
+ * Single source of truth for (re)generating AI Power Rankings with the v7.6
+ * algorithm and persisting a new snapshot. Both the manual
+ * `scripts/generate-v76-rankings.ts` CLI and the `/api/cron/regenerate-rankings`
+ * Vercel cron route call `regenerateRankings()` so the logic never drifts.
+ *
+ * Design:
+ * - `computeRankings()` is a PURE function (no DB, no clock) that scores + ranks
+ *   a set of tools. It is unit-tested directly.
+ * - `regenerateRankings()` orchestrates load -> compute -> persist. Its DB access
+ *   is injected via a `RankingPersistencePort` so it can be unit-tested with an
+ *   in-memory fake (no live database).
+ * - Persistence is atomic: within a single transaction we delete any existing
+ *   snapshot for the target period (idempotent re-runs), unset the prior
+ *   `is_current` row, then insert the new snapshot with `is_current = true`.
+ * - An in-process guard rejects concurrent runs for the same period; the unique
+ *   `rankings_period_idx` index is the durable backstop across instances.
+ */
+
+import { eq } from "drizzle-orm";
+import { getDb } from "@/lib/db/connection";
+import { rankings, tools } from "@/lib/db/schema";
+import { ALGORITHM_V76_WEIGHTS, RankingEngineV76 } from "@/lib/ranking-algorithm-v76";
+
+export const RANKING_ALGORITHM_VERSION = "7.6";
+
+/** Minimal tool shape required to score a tool. */
+export interface RankingSourceTool {
+  id: string;
+  name: string;
+  slug: string;
+  category: string;
+  status: string;
+  data: Record<string, unknown> | null;
+}
+
+/** A single persisted ranking row (shape stored in the snapshot JSONB). */
+export interface RankingEntry {
+  tool_id: string;
+  tool_name: string;
+  tool_slug: string;
+  rank: number;
+  score: number;
+  tier: string;
+  factor_scores: Record<string, number>;
+  category: string;
+  status: string;
+  movement: {
+    previous_position: number | null;
+    change: number;
+    direction: "up" | "down" | "same";
+  };
+}
+
+/** Summary returned to callers (cron route surfaces this as JSON). */
+export interface RankingGenerationResult {
+  period: string;
+  algorithmVersion: string;
+  toolCount: number;
+  publishedAt: string;
+  topMovers: Array<{ tool_name: string; previous_position: number | null; rank: number; change: number }>;
+}
+
+/** Injectable persistence boundary so orchestration is DB-agnostic in tests. */
+export interface RankingPersistencePort {
+  loadActiveTools(): Promise<RankingSourceTool[]>;
+  loadCurrentRankings(): Promise<{ data: unknown } | null>;
+  saveSnapshot(input: {
+    period: string;
+    algorithmVersion: string;
+    publishedAt: Date;
+    data: RankingEntry[];
+  }): Promise<void>;
+}
+
+export interface RegenerateRankingsOptions {
+  /** Target period, e.g. "2026-07". Defaults to the current UTC month. */
+  period?: string;
+  /** Injected persistence (defaults to the live Drizzle-backed adapter). */
+  persistence?: RankingPersistencePort;
+  /** Clock injection for deterministic tests. */
+  now?: () => Date;
+}
+
+/** Raised when a regeneration for the same period is already in flight. */
+export class RankingGenerationInProgressError extends Error {
+  constructor(public readonly period: string) {
+    super(`Ranking regeneration already in progress for period ${period}`);
+    this.name = "RankingGenerationInProgressError";
+  }
+}
+
+// In-process concurrency guard (per-instance). The unique period index in the DB
+// is the cross-instance backstop against duplicate snapshots.
+const inFlightPeriods = new Set<string>();
+
+/** Format a Date as a "YYYY-MM" period string in UTC. */
+export function toPeriod(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+/** Tier assignment by rank (matches the historical v7.6 CLI). */
+export function calculateTier(rank: number): string {
+  if (rank <= 5) return "S";
+  if (rank <= 15) return "A";
+  if (rank <= 30) return "B";
+  if (rank <= 45) return "C";
+  return "D";
+}
+
+/** Build a tool_id -> previous rank map from a prior snapshot's JSONB data. */
+export function buildPreviousRankMap(prevData: unknown): Map<string, number> {
+  const map = new Map<string, number>();
+  const list = Array.isArray(prevData)
+    ? prevData
+    : ((prevData as { rankings?: unknown[] } | null)?.rankings ?? []);
+
+  for (const raw of list as Array<Record<string, unknown>>) {
+    const toolId = (raw["tool_id"] ?? raw["id"]) as string | undefined;
+    const rank = (raw["rank"] ?? raw["position"]) as number | undefined;
+    if (toolId && rank) {
+      map.set(toolId, rank);
+    }
+  }
+  return map;
+}
+
+/**
+ * PURE: score, sort, rank, and shape a set of tools into ranking entries.
+ * No database, no wall-clock, no side effects — safe to unit test directly.
+ */
+export function computeRankings(
+  sourceTools: RankingSourceTool[],
+  previousRankMap: Map<string, number>,
+  currentDate: Date = new Date()
+): RankingEntry[] {
+  const engine = new RankingEngineV76(ALGORITHM_V76_WEIGHTS);
+
+  const scored = sourceTools
+    .map((tool) => {
+      const toolData = (tool.data ?? {}) as Record<string, unknown>;
+      const metrics = {
+        tool_id: tool.id,
+        name: tool.name,
+        slug: tool.slug,
+        category: tool.category,
+        status: tool.status,
+        info: toolData,
+        metrics: (toolData["metrics"] as Record<string, unknown>) ?? {},
+      };
+
+      const score = engine.calculateToolScore(metrics as never, currentDate);
+      return {
+        tool,
+        overallScore: score.overallScore,
+        factorScores: score.factorScores,
+      };
+    })
+    .sort((a, b) => b.overallScore - a.overallScore);
+
+  return scored.map((entry, index) => {
+    const rank = index + 1;
+    const prevRank = previousRankMap.get(entry.tool.id);
+    const change = prevRank ? prevRank - rank : 0;
+
+    return {
+      tool_id: entry.tool.id,
+      tool_name: entry.tool.name,
+      tool_slug: entry.tool.slug,
+      rank,
+      score: entry.overallScore,
+      tier: calculateTier(rank),
+      factor_scores: entry.factorScores,
+      category: entry.tool.category,
+      status: entry.tool.status,
+      movement: {
+        previous_position: prevRank ?? null,
+        change,
+        direction: change > 0 ? "up" : change < 0 ? "down" : "same",
+      },
+    };
+  });
+}
+
+/**
+ * Default persistence adapter backed by the live Drizzle connection.
+ * The snapshot write is a single atomic transaction.
+ */
+export function createDbPersistence(): RankingPersistencePort {
+  return {
+    async loadActiveTools() {
+      const db = getDb();
+      if (!db) throw new Error("Database connection not available");
+      const rows = await db.select().from(tools).where(eq(tools.status, "active"));
+      return rows.map((row) => ({
+        id: row.id,
+        name: row.name,
+        slug: row.slug,
+        category: row.category,
+        status: row.status,
+        data: (row.data ?? {}) as Record<string, unknown>,
+      }));
+    },
+
+    async loadCurrentRankings() {
+      const db = getDb();
+      if (!db) throw new Error("Database connection not available");
+      const result = await db
+        .select()
+        .from(rankings)
+        .where(eq(rankings.isCurrent, true))
+        .limit(1);
+      return result.length > 0 ? { data: result[0]!.data } : null;
+    },
+
+    async saveSnapshot({ period, algorithmVersion, publishedAt, data }) {
+      const db = getDb();
+      if (!db) throw new Error("Database connection not available");
+      await db.transaction(async (tx) => {
+        // Idempotent: drop any prior snapshot for this exact period.
+        await tx.delete(rankings).where(eq(rankings.period, period));
+        // Demote the previous current snapshot.
+        await tx.update(rankings).set({ isCurrent: false }).where(eq(rankings.isCurrent, true));
+        // Insert the fresh snapshot as current.
+        await tx.insert(rankings).values({
+          period,
+          algorithmVersion,
+          isCurrent: true,
+          publishedAt,
+          data: data as never,
+        });
+      });
+    },
+  };
+}
+
+/**
+ * Regenerate the v7.6 rankings and persist a new current snapshot.
+ *
+ * Idempotent per period (safe to re-run) and guarded against concurrent runs.
+ * Does NOT close the DB connection — callers that own the process lifecycle
+ * (the CLI script) are responsible for that.
+ */
+export async function regenerateRankings(
+  options: RegenerateRankingsOptions = {}
+): Promise<RankingGenerationResult> {
+  const now = options.now ?? (() => new Date());
+  const publishedAt = now();
+  const period = options.period ?? toPeriod(publishedAt);
+  const persistence = options.persistence ?? createDbPersistence();
+
+  if (inFlightPeriods.has(period)) {
+    throw new RankingGenerationInProgressError(period);
+  }
+  inFlightPeriods.add(period);
+
+  try {
+    const [sourceTools, prevSnapshot] = await Promise.all([
+      persistence.loadActiveTools(),
+      persistence.loadCurrentRankings(),
+    ]);
+
+    const previousRankMap = buildPreviousRankMap(prevSnapshot?.data ?? null);
+    const data = computeRankings(sourceTools, previousRankMap, publishedAt);
+
+    await persistence.saveSnapshot({
+      period,
+      algorithmVersion: RANKING_ALGORITHM_VERSION,
+      publishedAt,
+      data,
+    });
+
+    const topMovers = [...data]
+      .filter((r) => Math.abs(r.movement.change) >= 5)
+      .sort((a, b) => Math.abs(b.movement.change) - Math.abs(a.movement.change))
+      .slice(0, 5)
+      .map((r) => ({
+        tool_name: r.tool_name,
+        previous_position: r.movement.previous_position,
+        rank: r.rank,
+        change: r.movement.change,
+      }));
+
+    return {
+      period,
+      algorithmVersion: RANKING_ALGORITHM_VERSION,
+      toolCount: data.length,
+      publishedAt: publishedAt.toISOString(),
+      topMovers,
+    };
+  } finally {
+    inFlightPeriods.delete(period);
+  }
+}

--- a/scripts/generate-v76-rankings.ts
+++ b/scripts/generate-v76-rankings.ts
@@ -1,281 +1,81 @@
 #!/usr/bin/env tsx
 
 /**
- * Generate November 2025 Rankings with Algorithm v7.6 (Fine-Tuned Market + Innovation Balance)
+ * Generate Rankings with Algorithm v7.6 (Fine-Tuned Market + Innovation Balance)
  *
- * This version combines:
+ * Thin CLI wrapper around the shared `regenerateRankings()` service
+ * (lib/services/ranking-generation.service.ts) — the single source of truth
+ * used by both this script and the `/api/cron/regenerate-rankings` cron route.
+ *
+ * This wrapper adds only process-level concerns: human-readable console output,
+ * an optional `--period=YYYY-MM` override, and closing the DB connection on exit
+ * (the service intentionally leaves the pooled connection open for the serverless
+ * cron path).
+ *
+ * v7.6 combines:
  * 1. npm data quality fix (removed 15 incorrect mappings, 22.9M bogus downloads)
- * 2. Market-validated weights (40% adoption focus: Market Traction 12%, Innovation 10%, Resilience 8%)
+ * 2. Market-validated weights (40% adoption focus)
  * 3. Missing data penalty (confidence multiplier 0.7-1.0 based on completeness)
- *
- * Key Changes from v7.3:
- * - Increased Developer Adoption weight: 15% → 22%
- * - Increased Market Traction weight: 12% → 18%
- * - Added data completeness confidence multiplier
- * - Fixed data path mismatch (reads from metrics.metrics.* and info.*)
- *
- * Process:
- * 1. Delete existing 2025-11 rankings if present
- * 2. Load all active tools from database (with corrected npm data)
- * 3. Calculate scores using v7.6 algorithm (market-validated weights + missing data penalty)
- * 4. Sort and rank tools by score
- * 5. Compare with previous rankings for movement data
- * 6. Insert as new ranking period (2025-11)
- * 7. Mark as current (is_current = true)
  */
 
-import { closeDb, getDb } from "@/lib/db/connection";
-import { rankings, tools } from "@/lib/db/schema";
-import { eq } from "drizzle-orm";
-import { RankingEngineV76, ALGORITHM_V76_WEIGHTS } from "@/lib/ranking-algorithm-v76";
+import { closeDb } from "@/lib/db/connection";
+import { ALGORITHM_V76_WEIGHTS } from "@/lib/ranking-algorithm-v76";
+import { regenerateRankings } from "@/lib/services/ranking-generation.service";
 
-interface ToolScore {
-  tool_id: string;
-  tool_name: string;
-  tool_slug: string;
-  category: string;
-  status: string;
-  overall_score: number;
-  factor_scores: Record<string, number>;
-  rank: number;
+function parsePeriodArg(): string | undefined {
+  const arg = process.argv.find((a) => a.startsWith("--period="));
+  return arg ? arg.slice("--period=".length) : undefined;
 }
 
-function calculateTier(rank: number): string {
-  if (rank <= 5) return "S";
-  if (rank <= 15) return "A";
-  if (rank <= 30) return "B";
-  if (rank <= 45) return "C";
-  return "D";
-}
+async function main() {
+  const period = parsePeriodArg();
 
-async function generateV76Rankings() {
-  const db = getDb();
-  console.log("\n🚀 Generating November 2025 Rankings with Algorithm v7.6 (Market-Validated + npm Fix)\n");
+  console.log("\n🚀 Generating Rankings with Algorithm v7.6 (Market-Validated + npm Fix)\n");
   console.log("=".repeat(80));
   console.log("\n📊 Algorithm v7.6 Weights (Market-Validated):");
-  console.log(`   Agentic Capability:    ${ALGORITHM_V76_WEIGHTS.agenticCapability.toFixed(3)} (↓ from 0.100)`);
-  console.log(`   Innovation:            ${ALGORITHM_V76_WEIGHTS.innovation.toFixed(3)} (↓ from 0.100)`);
-  console.log(`   Technical Performance: ${ALGORITHM_V76_WEIGHTS.technicalPerformance.toFixed(3)} (unchanged)`);
-  console.log(`   Developer Adoption:    ${ALGORITHM_V76_WEIGHTS.developerAdoption.toFixed(3)} (↑ from 0.150) 🔥`);
-  console.log(`   Market Traction:       ${ALGORITHM_V76_WEIGHTS.marketTraction.toFixed(3)} (↑ from 0.120) 🔥`);
-  console.log(`   Business Sentiment:    ${ALGORITHM_V76_WEIGHTS.businessSentiment.toFixed(3)} (↓ from 0.130)`);
-  console.log(`   Development Velocity:  ${ALGORITHM_V76_WEIGHTS.developmentVelocity.toFixed(3)} (↓ from 0.140)`);
-  console.log(`   Platform Resilience:   ${ALGORITHM_V76_WEIGHTS.platformResilience.toFixed(3)} (↓ from 0.140)`);
+  console.log(`   Agentic Capability:    ${ALGORITHM_V76_WEIGHTS.agenticCapability.toFixed(3)}`);
+  console.log(`   Innovation:            ${ALGORITHM_V76_WEIGHTS.innovation.toFixed(3)}`);
+  console.log(`   Technical Performance: ${ALGORITHM_V76_WEIGHTS.technicalPerformance.toFixed(3)}`);
+  console.log(`   Developer Adoption:    ${ALGORITHM_V76_WEIGHTS.developerAdoption.toFixed(3)} 🔥`);
+  console.log(`   Market Traction:       ${ALGORITHM_V76_WEIGHTS.marketTraction.toFixed(3)} 🔥`);
+  console.log(`   Business Sentiment:    ${ALGORITHM_V76_WEIGHTS.businessSentiment.toFixed(3)}`);
+  console.log(`   Development Velocity:  ${ALGORITHM_V76_WEIGHTS.developmentVelocity.toFixed(3)}`);
+  console.log(`   Platform Resilience:   ${ALGORITHM_V76_WEIGHTS.platformResilience.toFixed(3)}`);
 
-  console.log("\n🎯 Total Adoption Focus:   40% (Developer + Market Traction)");
-  console.log("\n🔧 Additional Features:");
-  console.log("   ✓ Missing data penalty (0.7-1.0 confidence multiplier)");
-  console.log("   ✓ npm data quality fix (22.9M bogus downloads removed)");
-  console.log("   ✓ Dual data path support (metrics.metrics.* and info.*)");
+  console.log("\n🧮 Scoring active tools and persisting snapshot...");
+  const result = await regenerateRankings(period ? { period } : {});
 
-  // Step 0: Delete existing 2025-11 rankings if present
-  console.log("\n🗑️  Checking for existing 2025-11 rankings...");
-  try {
-    const existingRankings = await db
-      .select()
-      .from(rankings)
-      .where(eq(rankings.period, "2025-11"))
-      .limit(1);
+  console.log("\n" + "=".repeat(80));
+  console.log("✅ Rankings Generated Successfully (v7.6)!");
+  console.log("=".repeat(80));
+  console.log("\n📊 Summary:");
+  console.log(`   Period:            ${result.period}`);
+  console.log(`   Algorithm Version: v${result.algorithmVersion}`);
+  console.log(`   Total Tools:       ${result.toolCount}`);
+  console.log(`   Published At:      ${result.publishedAt}`);
 
-    if (existingRankings.length > 0) {
-      await db.delete(rankings).where(eq(rankings.period, "2025-11"));
-      console.log("✓ Deleted existing 2025-11 rankings to prevent duplicate key error");
-    } else {
-      console.log("✓ No existing 2025-11 rankings found");
-    }
-  } catch (error) {
-    console.warn("⚠️  Could not check/delete existing rankings:", error);
-  }
-
-  // Step 1: Get previous rankings for movement calculation
-  console.log("\n📥 Loading previous rankings for movement calculation...");
-  const prevRankingsResult = await db
-    .select()
-    .from(rankings)
-    .where(eq(rankings.isCurrent, true))
-    .limit(1);
-
-  const previousRankMap: Map<string, number> = new Map();
-
-  if (prevRankingsResult.length > 0) {
-    const prevData = prevRankingsResult[0].data as any;
-    const prevRankings = Array.isArray(prevData) ? prevData : prevData?.rankings || [];
-
-    prevRankings.forEach((r: any) => {
-      const toolId = r.tool_id || r.id;
-      const rank = r.rank || r.position;
-      if (toolId && rank) {
-        previousRankMap.set(toolId, rank);
-      }
-    });
-
-    console.log(`✓ Loaded ${previousRankMap.size} previous rankings for movement calculation`);
-  } else {
-    console.log("⚠️  No previous rankings found - all movements will be 'new'");
-  }
-
-  // Step 2: Load all active tools
-  console.log("\n📚 Loading active tools from database...");
-  const allTools = await db.select().from(tools).where(eq(tools.status, "active"));
-  console.log(`✓ Found ${allTools.length} active tools\n`);
-
-  // Step 3: Calculate scores with v7.6
-  console.log("🧮 Calculating scores with Algorithm v7.6 (Market-Validated + Missing Data Penalty)...\n");
-  const engine = new RankingEngineV76(ALGORITHM_V76_WEIGHTS);
-  const toolScores: ToolScore[] = [];
-
-  for (const tool of allTools) {
-    const toolData = tool.data as any;
-
-    const metrics = {
-      tool_id: tool.id,
-      name: tool.name,
-      slug: tool.slug,
-      category: tool.category,
-      status: tool.status,
-      info: toolData,
-      metrics: toolData.metrics || {}, // Pass nested metrics
-    };
-
-    try {
-      const score = engine.calculateToolScore(metrics);
-
-      toolScores.push({
-        tool_id: tool.id,
-        tool_name: tool.name,
-        tool_slug: tool.slug,
-        category: tool.category,
-        status: tool.status,
-        overall_score: score.overallScore,
-        factor_scores: score.factorScores,
-        rank: 0, // Will be assigned after sorting
-      });
-    } catch (error) {
-      console.error(`   ⚠️  Error scoring ${tool.name}:`, error);
-    }
-  }
-
-  // Step 4: Sort and assign ranks
-  toolScores.sort((a, b) => b.overall_score - a.overall_score);
-  toolScores.forEach((tool, index) => {
-    tool.rank = index + 1;
-  });
-
-  console.log(`✓ Scored and ranked ${toolScores.length} tools\n`);
-  console.log("🏆 Top 20 Rankings:\n");
-  console.log("Rank | Tool                         | Score | Tier | Movement");
-  console.log("-".repeat(75));
-
-  toolScores.slice(0, 20).forEach((tool) => {
-    const prevRank = previousRankMap.get(tool.tool_id);
-    let movement = "NEW";
-
-    if (prevRank) {
-      const change = prevRank - tool.rank;
-      if (change > 0) movement = `↑${change}`;
-      else if (change < 0) movement = `↓${Math.abs(change)}`;
-      else movement = "→";
-    }
-
-    console.log(
-      `${String(tool.rank).padStart(4)} | ` +
-      `${tool.tool_name.substring(0, 28).padEnd(28)} | ` +
-      `${tool.overall_score.toFixed(1).padStart(5)} | ` +
-      `${calculateTier(tool.rank).padStart(4)} | ` +
-      `${movement.padStart(8)}`
-    );
-  });
-
-  // Step 5: Build rankings data structure
-  const rankingsData = toolScores.map((tool) => {
-    const prevRank = previousRankMap.get(tool.tool_id);
-    const rankChange = prevRank ? prevRank - tool.rank : 0;
-
-    return {
-      tool_id: tool.tool_id,
-      tool_name: tool.tool_name,
-      tool_slug: tool.tool_slug,
-      rank: tool.rank,
-      score: tool.overall_score,
-      tier: calculateTier(tool.rank),
-      factor_scores: tool.factor_scores,
-      category: tool.category,
-      status: tool.status,
-      movement: {
-        previous_position: prevRank || null,
-        change: rankChange,
-        direction: rankChange > 0 ? "up" : rankChange < 0 ? "down" : "same",
-      },
-    };
-  });
-
-  // Step 6: Insert into database
-  console.log("\n\n💾 Inserting rankings into database...");
-
-  const period = "2025-11";
-  const algorithmVersion = "7.6";
-
-  try {
-    // First, unset all current rankings
-    await db.update(rankings).set({ isCurrent: false });
-    console.log("✓ Unmarked all previous rankings as current");
-
-    // Insert new rankings
-    await db.insert(rankings).values({
-      period,
-      algorithmVersion,
-      isCurrent: true,
-      publishedAt: new Date(),
-      data: rankingsData as any,
-    });
-
-    console.log(`✓ Inserted ${rankingsData.length} rankings for period ${period}`);
-    console.log(`✓ Marked as current with algorithm version ${algorithmVersion}`);
-
-    console.log("\n" + "=".repeat(80));
-    console.log("✅ November 2025 Rankings Generated Successfully (v7.6)!");
-    console.log("=".repeat(80));
-
-    console.log("\n📊 Summary:");
-    console.log(`   Period:            ${period}`);
-    console.log(`   Algorithm Version: v${algorithmVersion}`);
-    console.log(`   Total Tools:       ${rankingsData.length}`);
-    console.log(`   Timestamp:         ${new Date().toISOString()}`);
-    console.log(`   Is Current:        true`);
-
+  if (result.topMovers.length > 0) {
     console.log("\n🔥 Notable Changes:");
-    const significantMoves = rankingsData
-      .filter(r => Math.abs(r.movement.change) >= 5)
-      .sort((a, b) => Math.abs(b.movement.change) - Math.abs(a.movement.change))
-      .slice(0, 5);
-
-    if (significantMoves.length > 0) {
-      significantMoves.forEach(r => {
-        const direction = r.movement.change > 0 ? "↑" : "↓";
-        console.log(
-          `   ${direction} ${Math.abs(r.movement.change)} positions: ` +
-          `${r.tool_name} (#${r.movement.previous_position} → #${r.rank})`
-        );
-      });
-    } else {
-      console.log("   No significant position changes (±5 ranks)");
+    for (const mover of result.topMovers) {
+      const direction = mover.change > 0 ? "↑" : "↓";
+      console.log(
+        `   ${direction} ${Math.abs(mover.change)} positions: ` +
+          `${mover.tool_name} (#${mover.previous_position ?? "NEW"} → #${mover.rank})`
+      );
     }
-
-  } catch (error) {
-    console.error("\n❌ Error inserting rankings:", error);
-    throw error;
-  } finally {
-    await closeDb();
+  } else {
+    console.log("\n   No significant position changes (±5 ranks)");
   }
 }
 
-// Run the script
-generateV76Rankings()
-  .then(() => {
-    console.log("\n✨ Done! Rankings are now live with Algorithm v7.6 (market-validated + npm fix)\n");
+main()
+  .then(async () => {
+    await closeDb();
+    console.log("\n✨ Done! Rankings are now live with Algorithm v7.6.\n");
     process.exit(0);
   })
-  .catch((error) => {
+  .catch(async (error) => {
     console.error("\n💥 Fatal Error:", error);
+    await closeDb();
     process.exit(1);
   });

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/monthly-summary",
       "schedule": "0 8 1 * *"
+    },
+    {
+      "path": "/api/cron/regenerate-rankings",
+      "schedule": "0 9 1 * *"
     }
   ]
 }


### PR DESCRIPTION
Closes #78

Fixes the frozen-rankings root cause: regeneration is now scheduled infrastructure instead of a manual script nobody re-ran. Verified green: `tsc --noEmit` (0 errors), `npm run test:unit` (85 passed, incl. 11 new service tests), `next build` (success, new route in table). Lint skipped — no ESLint config (#82).

## Changes
- **Reusable service** `lib/services/ranking-generation.service.ts` — `regenerateRankings()` with atomic persist (delete-by-period → demote prior `is_current` → insert new snapshot), per-period concurrency guard, serverless-safe. `scripts/generate-v76-rankings.ts` refactored to a thin CLI wrapper (−256 lines), no copy-paste.
- **Cron route** `app/api/cron/regenerate-rankings/route.ts` — same `Bearer <CRON_SECRET>` auth as sibling crons (401 on mismatch), 409 on concurrent same-period run, returns a JSON summary.
- **Schedule** `vercel.json` — `{ "path": "/api/cron/regenerate-rankings", "schedule": "0 9 1 * *" }` (monthly, no collision with monthly-summary at 08:00).
- **Staleness marker** — `app/api/rankings/route.ts` exposes `published_at`/`period`; `components/ranking/rankings-grid.tsx` renders a localized "Rankings as of <date>"; `rankings.asOf` key added to all 10 locale dictionaries.

**No production regeneration was triggered** — infrastructure only. The first live regen is a coordinated follow-up so the fresh snapshot reflects the pruned taxonomy (#80 / PR #85).

Note: touches `i18n/dictionaries/en.json`, which PR #84 also edits — may need a trivial conflict resolution depending on merge order.

Generated with Claude Code