### PR TITLE
fix(admin): write rankings cache to real data/cache path + ensure parent dir exists

### DIFF
--- a/app/api/admin/rankings/rollback/[id]/route.ts
+++ b/app/api/admin/rankings/rollback/[id]/route.ts
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { type NextRequest, NextResponse } from "next/server";
+import { writeRankingsStaticCache } from "@/lib/cache/rankings-static-cache";
 
 interface Tool {
   name: string;
@@ -55,9 +56,8 @@ async function saveRankingsData(data: RankingsData) {
   const rankingsPath = path.join(process.cwd(), "public", "data", "rankings.json");
   await fs.writeFile(rankingsPath, JSON.stringify(data, null, 2));
 
-  // Also update the static cache
-  const cachePath = path.join(process.cwd(), "src", "data", "cache", "rankings-static.json");
-  await fs.writeFile(cachePath, JSON.stringify(data, null, 2));
+  // Also update the static cache (real dir is data/cache/; helper creates it if missing)
+  writeRankingsStaticCache(data);
 }
 
 async function loadVersionHistory(): Promise<RankingVersion[]> {

--- a/app/api/admin/rankings/route.ts
+++ b/app/api/admin/rankings/route.ts
@@ -12,9 +12,16 @@ import { writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { type NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
+import { writeRankingsStaticCache } from "@/lib/cache/rankings-static-cache";
 import { RankingsRepository } from "@/lib/db/repositories/rankings.repository";
 import { ToolsRepository } from "@/lib/db/repositories/tools.repository";
 import { loggers } from "@/lib/logger";
+// NOTE: The build/preview actions below still use the legacy RankingEngineV6.
+// The canonical regeneration path is now `regenerateRankings()` in
+// `@/lib/services/ranking-generation.service` (algorithm v7.6, see #86).
+// Consolidating onto it is deferred (#83 secondary) because the admin build
+// action is tightly coupled to V6's ToolMetricsV6/ToolScoreV6 score/weight
+// output contract; migrating it is a larger change than this ENOENT fix.
 import { RankingEngineV6, type ToolMetricsV6, type ToolScoreV6 } from "@/lib/ranking-algorithm-v6";
 
 // Helper function for category-based agentic scores
@@ -577,18 +584,10 @@ export async function POST(request: NextRequest) {
                 )
               );
 
-              const cachePath = join(process.cwd(), "src", "data", "cache", "rankings-static.json");
-              writeFileSync(
-                cachePath,
-                JSON.stringify(
-                  {
-                    ...latestRanking?.data,
-                    is_current: true,
-                  },
-                  null,
-                  2
-                )
-              );
+              writeRankingsStaticCache({
+                ...latestRanking?.data,
+                is_current: true,
+              });
 
               return NextResponse.json({
                 success: true,
@@ -615,18 +614,10 @@ export async function POST(request: NextRequest) {
           )
         );
 
-        const cachePath = join(process.cwd(), "src", "data", "cache", "rankings-static.json");
-        writeFileSync(
-          cachePath,
-          JSON.stringify(
-            {
-              ...currentData.data,
-              is_current: true,
-            },
-            null,
-            2
-          )
-        );
+        writeRankingsStaticCache({
+          ...currentData.data,
+          is_current: true,
+        });
 
         return NextResponse.json({
           success: true,

--- a/lib/cache/rankings-static-cache.test.ts
+++ b/lib/cache/rankings-static-cache.test.ts
@@ -1,0 +1,41 @@
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getRankingsStaticCachePath, writeRankingsStaticCache } from "./rankings-static-cache";
+
+describe("rankings-static-cache", () => {
+  const originalCwd = process.cwd();
+  let tmp: string;
+
+  beforeEach(() => {
+    // realpathSync resolves the macOS /var -> /private/var symlink so paths
+    // match what process.cwd() reports after chdir.
+    tmp = realpathSync(mkdtempSync(join(tmpdir(), "rankings-cache-")));
+    process.chdir(tmp);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("resolves to the real data/cache path, never the nonexistent src/data path", () => {
+    const p = getRankingsStaticCachePath();
+    expect(p).toBe(join(process.cwd(), "data", "cache", "rankings-static.json"));
+    expect(p.endsWith(join("data", "cache", "rankings-static.json"))).toBe(true);
+    expect(p).not.toContain(join("src", "data"));
+  });
+
+  it("creates the parent directory when missing (no ENOENT) and writes valid JSON", () => {
+    // The parent dir does not exist yet in the fresh temp cwd.
+    expect(existsSync(join(tmp, "data", "cache"))).toBe(false);
+
+    const payload = { rankings: [{ rank: 1 }], is_current: true };
+    const written = writeRankingsStaticCache(payload);
+
+    expect(written).toBe(join(tmp, "data", "cache", "rankings-static.json"));
+    expect(existsSync(written)).toBe(true);
+    expect(JSON.parse(readFileSync(written, "utf-8"))).toEqual(payload);
+  });
+});

--- a/lib/cache/rankings-static-cache.ts
+++ b/lib/cache/rankings-static-cache.ts
@@ -1,0 +1,26 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * Resolve the repo-relative path of the static rankings cache file.
+ *
+ * The real cache directory is `data/cache/` (there is no `src/data/` in the
+ * repo). Writing to a nonexistent `src/data/cache/…` path previously threw
+ * ENOENT and left this file silently stale (issue #83).
+ */
+export function getRankingsStaticCachePath(): string {
+  return join(process.cwd(), "data", "cache", "rankings-static.json");
+}
+
+/**
+ * Persist the static rankings cache, creating the parent directory if it is
+ * missing so a missing parent can never ENOENT.
+ *
+ * @returns the absolute path that was written.
+ */
+export function writeRankingsStaticCache(data: unknown): string {
+  const cachePath = getRankingsStaticCachePath();
+  mkdirSync(dirname(cachePath), { recursive: true });
+  writeFileSync(cachePath, JSON.stringify(data, null, 2));
+  return cachePath;
+}


### PR DESCRIPTION
Closes #83

## Problem
`app/api/admin/rankings/route.ts` (cache-sync) and `app/api/admin/rankings/rollback/[id]/route.ts` (rollback) wrote `rankings-static.json` to `join(process.cwd(), "src", "data", "cache", …)`. There is **no `src/data/` directory** in the repo — the real cache dir is `data/cache/` — and `writeFileSync` does not create missing parents, so every exercise of these admin actions threw **ENOENT**, leaving `data/cache/rankings-static.json` silently stale.

## Corrected path (evidence)
- The real file lives at repo-relative **`data/cache/rankings-static.json`** (present in the tree; `src/data/` does not exist anywhere — confirmed via `find`).
- The primary public read side (`app/[lang]/client-rankings*.tsx` → `fetch("/data/rankings.json")`, and both admin routes' `loadRankingsData`) reads `public/data/rankings.json`, which was already written correctly and is unchanged. Only the broken static-cache write target is corrected here.

## Changes
- New shared helper `lib/cache/rankings-static-cache.ts`:
  - `getRankingsStaticCachePath()` → `data/cache/rankings-static.json` (never `src/data`).
  - `writeRankingsStaticCache(data)` → `mkdirSync(dirname(path), { recursive: true })` **before** `writeFileSync`, so a missing parent can never ENOENT again.
- Wired all **three** call sites through the helper (2 in the admin rankings route, 1 in rollback).
- Added `lib/cache/rankings-static-cache.test.ts` asserting the path resolves to `data/cache/…` (not `src/data`) and that the write creates a missing parent dir and produces valid JSON.

## V6 secondary — NOT done (deferred, by design)
Issue #83 also notes the live admin route imports the legacy `RankingEngineV6`. The route's build/preview actions are tightly coupled to V6's `ToolMetricsV6`/`ToolScoreV6` score+weight output contract (two `new RankingEngineV6().calculateToolScore(...)` sites plus `getAlgorithmInfo().weights` and a `transformToToolMetrics` returning `ToolMetricsV6`). Pointing this at the canonical `regenerateRankings()` (v7.6, #86, different persistence-port/options signature) would change the admin build data flow and output contract — **not low-risk**, so per the issue's guidance it was **not forced**. Instead a code comment marks `regenerateRankings()` as the canonical path for a future consolidation.

## Verification (no DB touched — build/type/test only)
- `tsc --noEmit`: **0 errors** (EXIT=0)
- `npm run test:unit`: **96 passed, 77 skipped, 0 failed** (EXIT=0)
- `npm run build`: **Compiled successfully**, all `/api/admin/rankings*` routes built (EXIT=0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)