### PR TITLE
chore(lint): restore working ESLint config (next 15 + pragmatic rule tuning)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,8 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "warn",
+    "@typescript-eslint/no-require-imports": "warn",
+    "@next/next/no-html-link-for-pages": "warn"
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,8 @@ test-clerk-keys.js
 !package-lock.json
 !tsconfig.json
 !.mcp.json
+# .eslintrc.json is the lint config — must be tracked or the lint gate breaks (see issue #82)
+!.eslintrc.json
 
 # Added by Claude MPM /mpm-init
 $RECYCLE.BIN/

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "critters": "^0.0.23",
         "drizzle-kit": "^0.31.5",
         "eslint": "^8.57.1",
-        "eslint-config-next": "^14.2.18",
+        "eslint-config-next": "^15.5.9",
         "postcss": "^8",
         "puppeteer": "^24.22.3",
         "tailwindcss": "^3.4.16",
@@ -1943,55 +1943,43 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.18.tgz",
-      "integrity": "sha512-KyYTbZ3GQwWOjX3Vi1YcQbekyGP0gdammb7pbmmi25HBUCINzDReyrzCMOJIeZisK1Q3U6DT5Rlc4nm2/pQeXA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.20.tgz",
+      "integrity": "sha512-MZUgFpVd9rGSZpb8bNceUWvkAZe6aQw/6h2SSqHQuYzKfaiEUEVPIO6mXqaBmiBEBSN1f1sOc1uV8GCM90oegg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob": "10.3.10"
+        "fast-glob": "3.3.1"
       }
     },
-    "node_modules/@next/eslint-plugin-next/node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+    "node_modules/@next/eslint-plugin-next/node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/@next/eslint-plugin-next/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "is-glob": "^4.0.1"
       },
       "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@next/eslint-plugin-next/node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
+        "node": ">= 6"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -7055,25 +7043,25 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.18",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.18.tgz",
-      "integrity": "sha512-SuDRcpJY5VHBkhz5DijJ4iA4bVnBA0n48Rb+YSJSCDr+h7kKAcb1mZHusLbW+WA8LDB6edSolomXA55eG3eOVA==",
+      "version": "15.5.20",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.20.tgz",
+      "integrity": "sha512-Pl/I5544gmkcVVWcnaOMfhJSBK8lZ1NCJ+mGBkd2qvbGt2Gi7sEpgHF06OR13a2p6THODlncpvGsZzY2vUqwxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.18",
-        "@rushstack/eslint-patch": "^1.3.3",
+        "@next/eslint-plugin-next": "15.5.20",
+        "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.28.1",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^5.0.0"
       },
       "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0",
+        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
@@ -7333,16 +7321,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.0.0-canary-7118f5dd7-20230705",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
-      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "critters": "^0.0.23",
     "drizzle-kit": "^0.31.5",
     "eslint": "^8.57.1",
-    "eslint-config-next": "^14.2.18",
+    "eslint-config-next": "^15.5.9",
     "postcss": "^8",
     "puppeteer": "^24.22.3",
     "tailwindcss": "^3.4.16",


### PR DESCRIPTION
Closes #82

## Problem
No ESLint config file existed anywhere (`.eslintrc*` / `eslint.config.*` absent). `npm run lint` failed immediately with "No ESLint configuration found" — the lint gate was not lax, it was **broken**. A contributing root cause: `.gitignore`'s `/*.json` rule silently ignored any root `.eslintrc.json`, so the config could never be committed.

## Config approach
Least-invasive, standard path on the existing **ESLint 8** toolchain:
- Bumped `eslint-config-next` `14.2.18` → `^15.5.9` (installed `15.5.20`) to match Next `15.5.9`.
- Added a classic `.eslintrc.json` extending `next/core-web-vitals` + `next/typescript`.
- Kept the existing `lint` script (`eslint . --ext .js,.jsx,.ts,.tsx`) unchanged — `--ext` is valid on ESLint 8, so no script churn.
- Added `!.eslintrc.json` to `.gitignore` so the config is actually tracked (fixes the silent-ignore root cause).
- Left `.eslintignore` as-is (node_modules, .next, build artifacts, scripts-adjacent `*.config.*`, etc.).
- Did **not** touch `tsconfig.json`'s strict-exclude of `scripts/**` / `tests/**` — separate concern per the issue.

## Rules downgraded to `warn` (green, meaningful gate today — ratchet back to `error` later)
All three below were the **only** error-level rules flooding the gate. They are pervasive existing patterns or non-applicable to this App-Router project — none were isolated trivial fixes, so downgrading (not mass-rewriting) is the pragmatic call. They still surface as warnings.

| Rule | Count | Why downgraded |
|------|-------|----------------|
| `@typescript-eslint/no-explicit-any` | 1065 | Pervasive existing `any`/`as any` across the codebase; a repo-wide retype is out of scope for restoring the gate. Ratchet to `error` incrementally. |
| `@typescript-eslint/no-require-imports` | 24 | Existing `require()` usage (config/interop-style). Not a correctness issue; surface and migrate over time. |
| `@next/next/no-html-link-for-pages` | 69 | This is a **Pages-Router** rule; the project is pure App Router (`app/`, no `pages/`), so it misfires (it even flagged `app/api/**/route.ts`). Kept as `warn` for visibility rather than off. |

**Correctness rules kept as `error`** (untouched defaults): `react-hooks/rules-of-hooks`, `no-undef`, and everything else in `next/core-web-vitals` + `next/typescript`. Rules already at `warn` in the shared config (`no-unused-vars` 234, `no-img-element`, `react-hooks/exhaustive-deps`, `jsx-a11y/alt-text`) were left as-is.

## Verification (raw)
- `npm run lint` → `✖ 1408 problems (0 errors, 1408 warnings)` — **exit 0**
- `tsc --noEmit` → 0 errors, exit 0
- `npm run test:unit` → `Test Files 8 passed | 6 skipped` · `Tests 94 passed | 77 skipped`, exit 0
- `npm run build` → Compiled successfully, "Linting and checking validity of types" passed (warnings only), 87/87 static pages, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)