### PR TITLE
feat(rankings): research-augmented historical backfill (Dec 2025–Jun 2026)

### DIFF
--- a/data/historical-metrics/2025-12.json
+++ b/data/historical-metrics/2025-12.json
@@ -1,0 +1,529 @@
+{
+  "$schema": "historical-metrics-override/v1",
+  "period": "2025-12",
+  "reconstructed": true,
+  "generated_at": "2026-07-16T05:22:35.520Z",
+  "methodology_version": "1.0",
+  "notes": "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+  "fidelity_levels": {
+    "real": "Directly retrieved from an external time-series API for this exact calendar month.",
+    "interpolated": "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+    "held_flat": "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+    "not_applicable": "No value exists or is recoverable for this tool/metric/month."
+  },
+  "tools": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 21551967,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@anthropic-ai/claude-code",
+            "as_of": "2025-12",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2025-12, retrieved live from the npm range API for @anthropic-ai/claude-code."
+          }
+        },
+        "monthly_arr": {
+          "value": 1000000000,
+          "fidelity": "held_flat",
+          "source": "Anthropic: Claude Code hit $1B annualized within ~6 months of mid-2025 launch",
+          "as_of": "2025-12",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-12). Not a real 2025-12 reading."
+        },
+        "swe_bench": {
+          "verified": {
+            "value": 74.5,
+            "fidelity": "held_flat",
+            "source": "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)",
+            "as_of": "2025-08",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-08). Not a real 2025-12 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "github-copilot": {
+      "display_name": "GitHub Copilot",
+      "metrics": {
+        "users": {
+          "value": 1800000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~1.8M users (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-09). Not a real 2025-12 reading."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~$400M ARR (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-09). Not a real 2025-12 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "cursor": {
+      "display_name": "Cursor",
+      "metrics": {
+        "users": {
+          "value": 400000,
+          "fidelity": "held_flat",
+          "source": "Cursor ~360-400K paid users late 2025 (algorithm baseline)",
+          "as_of": "2025-12",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-12). Not a real 2025-12 reading."
+        },
+        "monthly_arr": {
+          "value": 1000000000,
+          "fidelity": "held_flat",
+          "source": "Cursor crossed $1B ARR late 2025 (TechCrunch)",
+          "as_of": "2025-12",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-12). Not a real 2025-12 reading."
+        },
+        "valuation": {
+          "value": 29300000000,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~$29.3B valuation (2025 round)",
+          "as_of": "2025-12",
+          "recovery_note": "No time-series API for valuation; held flat at the nearest dated anchor (2025-12). Not a real 2025-12 reading."
+        },
+        "employees": {
+          "value": 300,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~300 employees 2026 (jobsbyculture)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-06). Not a real 2025-12 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "chatgpt-canvas": {
+      "display_name": "ChatGPT Canvas",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "v0": {
+      "display_name": "v0",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "kiro": {
+      "display_name": "Kiro",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "windsurf": {
+      "display_name": "Windsurf",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-jules": {
+      "display_name": "Google Jules",
+      "metrics": {
+        "swe_bench": {
+          "verified": {
+            "value": 52.2,
+            "fidelity": "held_flat",
+            "source": "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)",
+            "as_of": "2025-06",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-06). Not a real 2025-12 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "amazon-q-developer": {
+      "display_name": "Amazon Q Developer",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "lovable": {
+      "display_name": "Lovable",
+      "metrics": {
+        "users": {
+          "value": 2760000,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Lovable 140K users (uuid-mappings: lovable-achieves-5-56m-arr)) and 2026-06 (Lovable ~8M users 2026 (getpanto))",
+          "as_of": "estimated for 2025-12",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 249180328,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-11 (Lovable $200M ARR Nov 2025 (TechCrunch)) and 2026-01 (Lovable $300M ARR Jan 2026 (TechCrunch))",
+          "as_of": "estimated for 2025-12",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 146,
+          "fidelity": "held_flat",
+          "source": "Lovable 146 employees (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-03). Not a real 2025-12 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "aider": {
+      "display_name": "Aider",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": null,
+            "fidelity": "not_applicable",
+            "source": "https://pypistats.org/api/packages/aider-chat/overall",
+            "as_of": null,
+            "recovery_note": "PyPI stats retain only a rolling ~180-day window; 2025-12 has rolled off (or the source was rate-limited). Poll monthly going forward rather than back-filling old months."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 38728,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/Aider-AI/aider (current stargazers_count=47416) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "tabnine": {
+      "display_name": "Tabnine",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "bolt-new": {
+      "display_name": "Bolt.new",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 11236,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/stackblitz/bolt.new (current stargazers_count=16460) linearly interpolated from repo creation 2024-09 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "monthly_arr": {
+          "value": 40000000,
+          "fidelity": "held_flat",
+          "source": "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)",
+          "as_of": "2025-08",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-08). Not a real 2025-12 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "augment-code": {
+      "display_name": "Augment Code",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-gemini-code-assist": {
+      "display_name": "Google Gemini Code Assist",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "replit-agent": {
+      "display_name": "Replit Agent",
+      "metrics": {
+        "users": {
+          "value": 45027624,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Replit 40M+ users Sep 2025 (Sacra)) and 2026-03 (Replit 50M+ users Mar 2026 (Sacra))",
+          "as_of": "estimated for 2025-12",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 300000000,
+          "fidelity": "held_flat",
+          "source": "Replit $300M ARR end-2025 (Sacra)",
+          "as_of": "2025-12",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-12). Not a real 2025-12 reading."
+        },
+        "valuation": {
+          "value": 6016574586,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Replit $3B valuation Sep 2025 (Prysm round)) and 2026-03 (Replit $9B valuation Mar 2026 (TechCrunch))",
+          "as_of": "estimated for 2025-12",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "zed": {
+      "display_name": "Zed",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 77714,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/zed-industries/zed (current stargazers_count=87054) linearly interpolated from repo creation 2021-02 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 1980311,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@openai/codex",
+            "as_of": "2025-12",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2025-12, retrieved live from the npm range API for @openai/codex."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 52746,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/openai/codex (current stargazers_count=98574) linearly interpolated from repo creation 2025-04 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "devin": {
+      "display_name": "Devin",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "continue": {
+      "display_name": "Continue",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 28511,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/continuedev/continue (current stargazers_count=34907) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=Continue.continue",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2025-12 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "claude-artifacts": {
+      "display_name": "Claude Artifacts",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcegraph-cody": {
+      "display_name": "Sourcegraph Cody",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "cline": {
+      "display_name": "Cline",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 45917,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/cline/cline (current stargazers_count=64709) linearly interpolated from repo creation 2024-07 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2025-12 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openhands": {
+      "display_name": "OpenHands",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": null,
+            "fidelity": "not_applicable",
+            "source": "https://pypistats.org/api/packages/openhands-ai/overall",
+            "as_of": null,
+            "recovery_note": "PyPI stats retain only a rolling ~180-day window; 2025-12 has rolled off (or the source was rate-limited). Poll monthly going forward rather than back-filling old months."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 60794,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/All-Hands-AI/OpenHands (current stargazers_count=80932) linearly interpolated from repo creation 2024-03 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "jetbrains-ai-assistant": {
+      "display_name": "JetBrains AI Assistant",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "qodo-gen": {
+      "display_name": "Qodo Gen",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "coderabbit": {
+      "display_name": "CodeRabbit",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "snyk-code": {
+      "display_name": "Snyk Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 1964024,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/snyk",
+            "as_of": "2025-12",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2025-12, retrieved live from the npm range API for snyk."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 5310,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/snyk/cli (current stargazers_count=5613) linearly interpolated from repo creation 2015-10 (0 stars) to 2026-07",
+            "as_of": "estimated for 2025-12",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "microsoft-intellicode": {
+      "display_name": "Microsoft IntelliCode",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcery": {
+      "display_name": "Sourcery",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "diffblue-cover": {
+      "display_name": "Diffblue Cover",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    }
+  }
+}

--- a/data/historical-metrics/2025-12.json
+++ b/data/historical-metrics/2025-12.json
@@ -114,7 +114,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "v0": {
+    "v0-vercel": {
       "display_name": "v0",
       "metrics": {},
       "provenance": {
@@ -262,7 +262,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "google-gemini-code-assist": {
+    "gemini-code-assist": {
       "display_name": "Google Gemini Code Assist",
       "metrics": {},
       "provenance": {
@@ -353,7 +353,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "continue": {
+    "continue-dev": {
       "display_name": "Continue",
       "metrics": {
         "github": {
@@ -450,7 +450,7 @@
         "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
       }
     },
-    "jetbrains-ai-assistant": {
+    "jetbrains-ai": {
       "display_name": "JetBrains AI Assistant",
       "metrics": {},
       "provenance": {

--- a/data/historical-metrics/2026-01.json
+++ b/data/historical-metrics/2026-01.json
@@ -1,0 +1,529 @@
+{
+  "$schema": "historical-metrics-override/v1",
+  "period": "2026-01",
+  "reconstructed": true,
+  "generated_at": "2026-07-16T05:22:35.520Z",
+  "methodology_version": "1.0",
+  "notes": "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+  "fidelity_levels": {
+    "real": "Directly retrieved from an external time-series API for this exact calendar month.",
+    "interpolated": "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+    "held_flat": "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+    "not_applicable": "No value exists or is recoverable for this tool/metric/month."
+  },
+  "tools": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 27575444,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@anthropic-ai/claude-code",
+            "as_of": "2026-01",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-01, retrieved live from the npm range API for @anthropic-ai/claude-code."
+          }
+        },
+        "monthly_arr": {
+          "value": 1750000000,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Anthropic: Claude Code hit $1B annualized within ~6 months of mid-2025 launch) and 2026-02 (Claude Code run-rate >$2.5B by Feb 2026 (VentureBeat/Sacra))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "swe_bench": {
+          "verified": {
+            "value": 74.5,
+            "fidelity": "held_flat",
+            "source": "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)",
+            "as_of": "2025-08",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-08). Not a real 2026-01 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "github-copilot": {
+      "display_name": "GitHub Copilot",
+      "metrics": {
+        "users": {
+          "value": 1800000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~1.8M users (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-09). Not a real 2026-01 reading."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~$400M ARR (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-09). Not a real 2026-01 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "cursor": {
+      "display_name": "Cursor",
+      "metrics": {
+        "users": {
+          "value": 502198,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Cursor ~360-400K paid users late 2025 (algorithm baseline)) and 2026-06 (Cursor ~1M users mid-2026 (estimate))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 1500000000,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Cursor crossed $1B ARR late 2025 (TechCrunch)) and 2026-02 (Anysphere >$2B annualized run-rate by Feb 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 34529120879,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Anysphere ~$29.3B valuation (2025 round)) and 2026-06 (Cursor $60B valuation, SpaceX acquisition announced 2026-06-16)",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 300,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~300 employees 2026 (jobsbyculture)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-06). Not a real 2026-01 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "chatgpt-canvas": {
+      "display_name": "ChatGPT Canvas",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "v0": {
+      "display_name": "v0",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "kiro": {
+      "display_name": "Kiro",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "windsurf": {
+      "display_name": "Windsurf",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-jules": {
+      "display_name": "Google Jules",
+      "metrics": {
+        "swe_bench": {
+          "verified": {
+            "value": 52.2,
+            "fidelity": "held_flat",
+            "source": "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)",
+            "as_of": "2025-06",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-06). Not a real 2026-01 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "amazon-q-developer": {
+      "display_name": "Amazon Q Developer",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "lovable": {
+      "display_name": "Lovable",
+      "metrics": {
+        "users": {
+          "value": 3652527,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Lovable 140K users (uuid-mappings: lovable-achieves-5-56m-arr)) and 2026-06 (Lovable ~8M users 2026 (getpanto))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 300000000,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-11 (Lovable $200M ARR Nov 2025 (TechCrunch)) and 2026-01 (Lovable $300M ARR Jan 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 146,
+          "fidelity": "held_flat",
+          "source": "Lovable 146 employees (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-03). Not a real 2026-01 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "aider": {
+      "display_name": "Aider",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 272089,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/aider-chat/overall",
+            "as_of": "2026-01",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-01 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 39998,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/Aider-AI/aider (current stargazers_count=47416) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "tabnine": {
+      "display_name": "Tabnine",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "bolt-new": {
+      "display_name": "Bolt.new",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 12000,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/stackblitz/bolt.new (current stargazers_count=16460) linearly interpolated from repo creation 2024-09 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "monthly_arr": {
+          "value": 40000000,
+          "fidelity": "held_flat",
+          "source": "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)",
+          "as_of": "2025-08",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-08). Not a real 2026-01 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "augment-code": {
+      "display_name": "Augment Code",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-gemini-code-assist": {
+      "display_name": "Google Gemini Code Assist",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "replit-agent": {
+      "display_name": "Replit Agent",
+      "metrics": {
+        "users": {
+          "value": 46740331,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Replit 40M+ users Sep 2025 (Sacra)) and 2026-03 (Replit 50M+ users Mar 2026 (Sacra))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 357644628,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Replit $300M ARR end-2025 (Sacra)) and 2026-04 (Replit $525M annualized Apr 2026 (Forbes/Sacra))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 7044198895,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Replit $3B valuation Sep 2025 (Prysm round)) and 2026-03 (Replit $9B valuation Mar 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-01",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "zed": {
+      "display_name": "Zed",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 79080,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/zed-industries/zed (current stargazers_count=87054) linearly interpolated from repo creation 2021-02 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 2327895,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@openai/codex",
+            "as_of": "2026-01",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-01, retrieved live from the npm range API for @openai/codex."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 59447,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/openai/codex (current stargazers_count=98574) linearly interpolated from repo creation 2025-04 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "devin": {
+      "display_name": "Devin",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "continue": {
+      "display_name": "Continue",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 29446,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/continuedev/continue (current stargazers_count=34907) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=Continue.continue",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-01 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "claude-artifacts": {
+      "display_name": "Claude Artifacts",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcegraph-cody": {
+      "display_name": "Sourcegraph Cody",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "cline": {
+      "display_name": "Cline",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 48665,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/cline/cline (current stargazers_count=64709) linearly interpolated from repo creation 2024-07 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-01 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openhands": {
+      "display_name": "OpenHands",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 174790,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/openhands-ai/overall",
+            "as_of": "2026-01",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-01 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 63739,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/All-Hands-AI/OpenHands (current stargazers_count=80932) linearly interpolated from repo creation 2024-03 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "jetbrains-ai-assistant": {
+      "display_name": "JetBrains AI Assistant",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "qodo-gen": {
+      "display_name": "Qodo Gen",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "coderabbit": {
+      "display_name": "CodeRabbit",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "snyk-code": {
+      "display_name": "Snyk Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 2127819,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/snyk",
+            "as_of": "2026-01",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-01, retrieved live from the npm range API for snyk."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 5354,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/snyk/cli (current stargazers_count=5613) linearly interpolated from repo creation 2015-10 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-01",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "microsoft-intellicode": {
+      "display_name": "Microsoft IntelliCode",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcery": {
+      "display_name": "Sourcery",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "diffblue-cover": {
+      "display_name": "Diffblue Cover",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    }
+  }
+}

--- a/data/historical-metrics/2026-01.json
+++ b/data/historical-metrics/2026-01.json
@@ -114,7 +114,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "v0": {
+    "v0-vercel": {
       "display_name": "v0",
       "metrics": {},
       "provenance": {
@@ -262,7 +262,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "google-gemini-code-assist": {
+    "gemini-code-assist": {
       "display_name": "Google Gemini Code Assist",
       "metrics": {},
       "provenance": {
@@ -353,7 +353,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "continue": {
+    "continue-dev": {
       "display_name": "Continue",
       "metrics": {
         "github": {
@@ -450,7 +450,7 @@
         "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
       }
     },
-    "jetbrains-ai-assistant": {
+    "jetbrains-ai": {
       "display_name": "JetBrains AI Assistant",
       "metrics": {},
       "provenance": {

--- a/data/historical-metrics/2026-02.json
+++ b/data/historical-metrics/2026-02.json
@@ -1,0 +1,529 @@
+{
+  "$schema": "historical-metrics-override/v1",
+  "period": "2026-02",
+  "reconstructed": true,
+  "generated_at": "2026-07-16T05:22:35.520Z",
+  "methodology_version": "1.0",
+  "notes": "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+  "fidelity_levels": {
+    "real": "Directly retrieved from an external time-series API for this exact calendar month.",
+    "interpolated": "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+    "held_flat": "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+    "not_applicable": "No value exists or is recoverable for this tool/metric/month."
+  },
+  "tools": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 30510428,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@anthropic-ai/claude-code",
+            "as_of": "2026-02",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-02, retrieved live from the npm range API for @anthropic-ai/claude-code."
+          }
+        },
+        "monthly_arr": {
+          "value": 2500000000,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Anthropic: Claude Code hit $1B annualized within ~6 months of mid-2025 launch) and 2026-02 (Claude Code run-rate >$2.5B by Feb 2026 (VentureBeat/Sacra))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "swe_bench": {
+          "verified": {
+            "value": 74.5,
+            "fidelity": "held_flat",
+            "source": "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)",
+            "as_of": "2025-08",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-08). Not a real 2026-02 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "github-copilot": {
+      "display_name": "GitHub Copilot",
+      "metrics": {
+        "users": {
+          "value": 1800000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~1.8M users (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-09). Not a real 2026-02 reading."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~$400M ARR (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-09). Not a real 2026-02 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "cursor": {
+      "display_name": "Cursor",
+      "metrics": {
+        "users": {
+          "value": 604396,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Cursor ~360-400K paid users late 2025 (algorithm baseline)) and 2026-06 (Cursor ~1M users mid-2026 (estimate))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 2000000000,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Cursor crossed $1B ARR late 2025 (TechCrunch)) and 2026-02 (Anysphere >$2B annualized run-rate by Feb 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 39758241758,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Anysphere ~$29.3B valuation (2025 round)) and 2026-06 (Cursor $60B valuation, SpaceX acquisition announced 2026-06-16)",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 300,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~300 employees 2026 (jobsbyculture)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-06). Not a real 2026-02 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "chatgpt-canvas": {
+      "display_name": "ChatGPT Canvas",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "v0": {
+      "display_name": "v0",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "kiro": {
+      "display_name": "Kiro",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "windsurf": {
+      "display_name": "Windsurf",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-jules": {
+      "display_name": "Google Jules",
+      "metrics": {
+        "swe_bench": {
+          "verified": {
+            "value": 52.2,
+            "fidelity": "held_flat",
+            "source": "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)",
+            "as_of": "2025-06",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-06). Not a real 2026-02 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "amazon-q-developer": {
+      "display_name": "Amazon Q Developer",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "lovable": {
+      "display_name": "Lovable",
+      "metrics": {
+        "users": {
+          "value": 4545055,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Lovable 140K users (uuid-mappings: lovable-achieves-5-56m-arr)) and 2026-06 (Lovable ~8M users 2026 (getpanto))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-01 (Lovable $300M ARR Jan 2026 (TechCrunch)) and 2026-02 (Lovable $400M ARR Feb 2026 (Bloomberg))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 146,
+          "fidelity": "held_flat",
+          "source": "Lovable 146 employees (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-03). Not a real 2026-02 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "aider": {
+      "display_name": "Aider",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 607342,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/aider-chat/overall",
+            "as_of": "2026-02",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-02 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 41269,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/Aider-AI/aider (current stargazers_count=47416) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "tabnine": {
+      "display_name": "Tabnine",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "bolt-new": {
+      "display_name": "Bolt.new",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 12764,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/stackblitz/bolt.new (current stargazers_count=16460) linearly interpolated from repo creation 2024-09 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "monthly_arr": {
+          "value": 40000000,
+          "fidelity": "held_flat",
+          "source": "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)",
+          "as_of": "2025-08",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-08). Not a real 2026-02 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "augment-code": {
+      "display_name": "Augment Code",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-gemini-code-assist": {
+      "display_name": "Google Gemini Code Assist",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "replit-agent": {
+      "display_name": "Replit Agent",
+      "metrics": {
+        "users": {
+          "value": 48453039,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Replit 40M+ users Sep 2025 (Sacra)) and 2026-03 (Replit 50M+ users Mar 2026 (Sacra))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 415289256,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Replit $300M ARR end-2025 (Sacra)) and 2026-04 (Replit $525M annualized Apr 2026 (Forbes/Sacra))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 8071823204,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Replit $3B valuation Sep 2025 (Prysm round)) and 2026-03 (Replit $9B valuation Mar 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-02",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "zed": {
+      "display_name": "Zed",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 80446,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/zed-industries/zed (current stargazers_count=87054) linearly interpolated from repo creation 2021-02 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 5801153,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@openai/codex",
+            "as_of": "2026-02",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-02, retrieved live from the npm range API for @openai/codex."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 66148,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/openai/codex (current stargazers_count=98574) linearly interpolated from repo creation 2025-04 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "devin": {
+      "display_name": "Devin",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "continue": {
+      "display_name": "Continue",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 30381,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/continuedev/continue (current stargazers_count=34907) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=Continue.continue",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-02 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "claude-artifacts": {
+      "display_name": "Claude Artifacts",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcegraph-cody": {
+      "display_name": "Sourcegraph Cody",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "cline": {
+      "display_name": "Cline",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 51413,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/cline/cline (current stargazers_count=64709) linearly interpolated from repo creation 2024-07 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-02 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openhands": {
+      "display_name": "OpenHands",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 717635,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/openhands-ai/overall",
+            "as_of": "2026-02",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-02 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 66683,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/All-Hands-AI/OpenHands (current stargazers_count=80932) linearly interpolated from repo creation 2024-03 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "jetbrains-ai-assistant": {
+      "display_name": "JetBrains AI Assistant",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "qodo-gen": {
+      "display_name": "Qodo Gen",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "coderabbit": {
+      "display_name": "CodeRabbit",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "snyk-code": {
+      "display_name": "Snyk Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 2243430,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/snyk",
+            "as_of": "2026-02",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-02, retrieved live from the npm range API for snyk."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 5399,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/snyk/cli (current stargazers_count=5613) linearly interpolated from repo creation 2015-10 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-02",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "microsoft-intellicode": {
+      "display_name": "Microsoft IntelliCode",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcery": {
+      "display_name": "Sourcery",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "diffblue-cover": {
+      "display_name": "Diffblue Cover",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    }
+  }
+}

--- a/data/historical-metrics/2026-02.json
+++ b/data/historical-metrics/2026-02.json
@@ -114,7 +114,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "v0": {
+    "v0-vercel": {
       "display_name": "v0",
       "metrics": {},
       "provenance": {
@@ -262,7 +262,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "google-gemini-code-assist": {
+    "gemini-code-assist": {
       "display_name": "Google Gemini Code Assist",
       "metrics": {},
       "provenance": {
@@ -353,7 +353,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "continue": {
+    "continue-dev": {
       "display_name": "Continue",
       "metrics": {
         "github": {
@@ -450,7 +450,7 @@
         "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
       }
     },
-    "jetbrains-ai-assistant": {
+    "jetbrains-ai": {
       "display_name": "JetBrains AI Assistant",
       "metrics": {},
       "provenance": {

--- a/data/historical-metrics/2026-03.json
+++ b/data/historical-metrics/2026-03.json
@@ -114,7 +114,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "v0": {
+    "v0-vercel": {
       "display_name": "v0",
       "metrics": {},
       "provenance": {
@@ -262,7 +262,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "google-gemini-code-assist": {
+    "gemini-code-assist": {
       "display_name": "Google Gemini Code Assist",
       "metrics": {},
       "provenance": {
@@ -353,7 +353,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "continue": {
+    "continue-dev": {
       "display_name": "Continue",
       "metrics": {
         "github": {
@@ -450,7 +450,7 @@
         "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
       }
     },
-    "jetbrains-ai-assistant": {
+    "jetbrains-ai": {
       "display_name": "JetBrains AI Assistant",
       "metrics": {},
       "provenance": {

--- a/data/historical-metrics/2026-03.json
+++ b/data/historical-metrics/2026-03.json
@@ -1,0 +1,529 @@
+{
+  "$schema": "historical-metrics-override/v1",
+  "period": "2026-03",
+  "reconstructed": true,
+  "generated_at": "2026-07-16T05:22:35.520Z",
+  "methodology_version": "1.0",
+  "notes": "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+  "fidelity_levels": {
+    "real": "Directly retrieved from an external time-series API for this exact calendar month.",
+    "interpolated": "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+    "held_flat": "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+    "not_applicable": "No value exists or is recoverable for this tool/metric/month."
+  },
+  "tools": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 44445736,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@anthropic-ai/claude-code",
+            "as_of": "2026-03",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-03, retrieved live from the npm range API for @anthropic-ai/claude-code."
+          }
+        },
+        "monthly_arr": {
+          "value": 4230337079,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Claude Code run-rate >$2.5B by Feb 2026 (VentureBeat/Sacra)) and 2026-05 (Claude Code ~$8B annualized run-rate by May 2026 (Sacra/Anthropic))",
+          "as_of": "estimated for 2026-03",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "swe_bench": {
+          "verified": {
+            "value": 74.5,
+            "fidelity": "held_flat",
+            "source": "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)",
+            "as_of": "2025-08",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-08). Not a real 2026-03 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "github-copilot": {
+      "display_name": "GitHub Copilot",
+      "metrics": {
+        "users": {
+          "value": 1800000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~1.8M users (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-09). Not a real 2026-03 reading."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~$400M ARR (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-09). Not a real 2026-03 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "cursor": {
+      "display_name": "Cursor",
+      "metrics": {
+        "users": {
+          "value": 696703,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Cursor ~360-400K paid users late 2025 (algorithm baseline)) and 2026-06 (Cursor ~1M users mid-2026 (estimate))",
+          "as_of": "estimated for 2026-03",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 2466666667,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Anysphere >$2B annualized run-rate by Feb 2026 (TechCrunch)) and 2026-06 (Cursor ~$4B annualized revenue by Jun 2026 (multiple))",
+          "as_of": "estimated for 2026-03",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 44481318681,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Anysphere ~$29.3B valuation (2025 round)) and 2026-06 (Cursor $60B valuation, SpaceX acquisition announced 2026-06-16)",
+          "as_of": "estimated for 2026-03",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 300,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~300 employees 2026 (jobsbyculture)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-06). Not a real 2026-03 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "chatgpt-canvas": {
+      "display_name": "ChatGPT Canvas",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "v0": {
+      "display_name": "v0",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "kiro": {
+      "display_name": "Kiro",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "windsurf": {
+      "display_name": "Windsurf",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-jules": {
+      "display_name": "Google Jules",
+      "metrics": {
+        "swe_bench": {
+          "verified": {
+            "value": 52.2,
+            "fidelity": "held_flat",
+            "source": "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)",
+            "as_of": "2025-06",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-06). Not a real 2026-03 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "amazon-q-developer": {
+      "display_name": "Amazon Q Developer",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "lovable": {
+      "display_name": "Lovable",
+      "metrics": {
+        "users": {
+          "value": 5351209,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Lovable 140K users (uuid-mappings: lovable-achieves-5-56m-arr)) and 2026-06 (Lovable ~8M users 2026 (getpanto))",
+          "as_of": "estimated for 2026-03",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 423333333,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Lovable $400M ARR Feb 2026 (Bloomberg)) and 2026-06 (Lovable $500M annualized Jun 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-03",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 146,
+          "fidelity": "held_flat",
+          "source": "Lovable 146 employees (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-03). Not a real 2026-03 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "aider": {
+      "display_name": "Aider",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 854006,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/aider-chat/overall",
+            "as_of": "2026-03",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-03 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 42416,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/Aider-AI/aider (current stargazers_count=47416) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "tabnine": {
+      "display_name": "Tabnine",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "bolt-new": {
+      "display_name": "Bolt.new",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 13454,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/stackblitz/bolt.new (current stargazers_count=16460) linearly interpolated from repo creation 2024-09 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "monthly_arr": {
+          "value": 40000000,
+          "fidelity": "held_flat",
+          "source": "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)",
+          "as_of": "2025-08",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-08). Not a real 2026-03 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "augment-code": {
+      "display_name": "Augment Code",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-gemini-code-assist": {
+      "display_name": "Google Gemini Code Assist",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "replit-agent": {
+      "display_name": "Replit Agent",
+      "metrics": {
+        "users": {
+          "value": 50000000,
+          "fidelity": "held_flat",
+          "source": "Replit 50M+ users Mar 2026 (Sacra)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2026-03). Not a real 2026-03 reading."
+        },
+        "monthly_arr": {
+          "value": 467355372,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Replit $300M ARR end-2025 (Sacra)) and 2026-04 (Replit $525M annualized Apr 2026 (Forbes/Sacra))",
+          "as_of": "estimated for 2026-03",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 9000000000,
+          "fidelity": "held_flat",
+          "source": "Replit $9B valuation Mar 2026 (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for valuation; held flat at the nearest dated anchor (2026-03). Not a real 2026-03 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "zed": {
+      "display_name": "Zed",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 81679,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/zed-industries/zed (current stargazers_count=87054) linearly interpolated from repo creation 2021-02 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 14529757,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@openai/codex",
+            "as_of": "2026-03",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-03, retrieved live from the npm range API for @openai/codex."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 72201,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/openai/codex (current stargazers_count=98574) linearly interpolated from repo creation 2025-04 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "devin": {
+      "display_name": "Devin",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "continue": {
+      "display_name": "Continue",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 31226,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/continuedev/continue (current stargazers_count=34907) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=Continue.continue",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-03 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "claude-artifacts": {
+      "display_name": "Claude Artifacts",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcegraph-cody": {
+      "display_name": "Sourcegraph Cody",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "cline": {
+      "display_name": "Cline",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 53895,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/cline/cline (current stargazers_count=64709) linearly interpolated from repo creation 2024-07 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-03 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openhands": {
+      "display_name": "OpenHands",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 1469745,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/openhands-ai/overall",
+            "as_of": "2026-03",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-03 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 69343,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/All-Hands-AI/OpenHands (current stargazers_count=80932) linearly interpolated from repo creation 2024-03 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "jetbrains-ai-assistant": {
+      "display_name": "JetBrains AI Assistant",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "qodo-gen": {
+      "display_name": "Qodo Gen",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "coderabbit": {
+      "display_name": "CodeRabbit",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "snyk-code": {
+      "display_name": "Snyk Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 2661194,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/snyk",
+            "as_of": "2026-03",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-03, retrieved live from the npm range API for snyk."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 5439,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/snyk/cli (current stargazers_count=5613) linearly interpolated from repo creation 2015-10 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-03",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "microsoft-intellicode": {
+      "display_name": "Microsoft IntelliCode",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcery": {
+      "display_name": "Sourcery",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "diffblue-cover": {
+      "display_name": "Diffblue Cover",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    }
+  }
+}

--- a/data/historical-metrics/2026-04.json
+++ b/data/historical-metrics/2026-04.json
@@ -114,7 +114,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "v0": {
+    "v0-vercel": {
       "display_name": "v0",
       "metrics": {},
       "provenance": {
@@ -262,7 +262,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "google-gemini-code-assist": {
+    "gemini-code-assist": {
       "display_name": "Google Gemini Code Assist",
       "metrics": {},
       "provenance": {
@@ -353,7 +353,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "continue": {
+    "continue-dev": {
       "display_name": "Continue",
       "metrics": {
         "github": {
@@ -450,7 +450,7 @@
         "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
       }
     },
-    "jetbrains-ai-assistant": {
+    "jetbrains-ai": {
       "display_name": "JetBrains AI Assistant",
       "metrics": {},
       "provenance": {

--- a/data/historical-metrics/2026-04.json
+++ b/data/historical-metrics/2026-04.json
@@ -1,0 +1,529 @@
+{
+  "$schema": "historical-metrics-override/v1",
+  "period": "2026-04",
+  "reconstructed": true,
+  "generated_at": "2026-07-16T05:22:35.520Z",
+  "methodology_version": "1.0",
+  "notes": "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+  "fidelity_levels": {
+    "real": "Directly retrieved from an external time-series API for this exact calendar month.",
+    "interpolated": "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+    "held_flat": "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+    "not_applicable": "No value exists or is recoverable for this tool/metric/month."
+  },
+  "tools": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 49361496,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@anthropic-ai/claude-code",
+            "as_of": "2026-04",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-04, retrieved live from the npm range API for @anthropic-ai/claude-code."
+          }
+        },
+        "monthly_arr": {
+          "value": 6146067416,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Claude Code run-rate >$2.5B by Feb 2026 (VentureBeat/Sacra)) and 2026-05 (Claude Code ~$8B annualized run-rate by May 2026 (Sacra/Anthropic))",
+          "as_of": "estimated for 2026-04",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "swe_bench": {
+          "verified": {
+            "value": 74.5,
+            "fidelity": "held_flat",
+            "source": "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)",
+            "as_of": "2025-08",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-08). Not a real 2026-04 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "github-copilot": {
+      "display_name": "GitHub Copilot",
+      "metrics": {
+        "users": {
+          "value": 1800000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~1.8M users (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-09). Not a real 2026-04 reading."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~$400M ARR (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-09). Not a real 2026-04 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "cursor": {
+      "display_name": "Cursor",
+      "metrics": {
+        "users": {
+          "value": 798901,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Cursor ~360-400K paid users late 2025 (algorithm baseline)) and 2026-06 (Cursor ~1M users mid-2026 (estimate))",
+          "as_of": "estimated for 2026-04",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 2983333333,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Anysphere >$2B annualized run-rate by Feb 2026 (TechCrunch)) and 2026-06 (Cursor ~$4B annualized revenue by Jun 2026 (multiple))",
+          "as_of": "estimated for 2026-04",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 49710439560,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Anysphere ~$29.3B valuation (2025 round)) and 2026-06 (Cursor $60B valuation, SpaceX acquisition announced 2026-06-16)",
+          "as_of": "estimated for 2026-04",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 300,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~300 employees 2026 (jobsbyculture)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-06). Not a real 2026-04 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "chatgpt-canvas": {
+      "display_name": "ChatGPT Canvas",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "v0": {
+      "display_name": "v0",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "kiro": {
+      "display_name": "Kiro",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "windsurf": {
+      "display_name": "Windsurf",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-jules": {
+      "display_name": "Google Jules",
+      "metrics": {
+        "swe_bench": {
+          "verified": {
+            "value": 52.2,
+            "fidelity": "held_flat",
+            "source": "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)",
+            "as_of": "2025-06",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-06). Not a real 2026-04 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "amazon-q-developer": {
+      "display_name": "Amazon Q Developer",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "lovable": {
+      "display_name": "Lovable",
+      "metrics": {
+        "users": {
+          "value": 6243736,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Lovable 140K users (uuid-mappings: lovable-achieves-5-56m-arr)) and 2026-06 (Lovable ~8M users 2026 (getpanto))",
+          "as_of": "estimated for 2026-04",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 449166667,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Lovable $400M ARR Feb 2026 (Bloomberg)) and 2026-06 (Lovable $500M annualized Jun 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-04",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 146,
+          "fidelity": "held_flat",
+          "source": "Lovable 146 employees (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-03). Not a real 2026-04 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "aider": {
+      "display_name": "Aider",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 855681,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/aider-chat/overall",
+            "as_of": "2026-04",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-04 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 43687,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/Aider-AI/aider (current stargazers_count=47416) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "tabnine": {
+      "display_name": "Tabnine",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "bolt-new": {
+      "display_name": "Bolt.new",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 14218,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/stackblitz/bolt.new (current stargazers_count=16460) linearly interpolated from repo creation 2024-09 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "monthly_arr": {
+          "value": 40000000,
+          "fidelity": "held_flat",
+          "source": "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)",
+          "as_of": "2025-08",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-08). Not a real 2026-04 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "augment-code": {
+      "display_name": "Augment Code",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-gemini-code-assist": {
+      "display_name": "Google Gemini Code Assist",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "replit-agent": {
+      "display_name": "Replit Agent",
+      "metrics": {
+        "users": {
+          "value": 50000000,
+          "fidelity": "held_flat",
+          "source": "Replit 50M+ users Mar 2026 (Sacra)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2026-03). Not a real 2026-04 reading."
+        },
+        "monthly_arr": {
+          "value": 525000000,
+          "fidelity": "held_flat",
+          "source": "Replit $525M annualized Apr 2026 (Forbes/Sacra)",
+          "as_of": "2026-04",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2026-04). Not a real 2026-04 reading."
+        },
+        "valuation": {
+          "value": 9000000000,
+          "fidelity": "held_flat",
+          "source": "Replit $9B valuation Mar 2026 (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for valuation; held flat at the nearest dated anchor (2026-03). Not a real 2026-04 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "zed": {
+      "display_name": "Zed",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 83045,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/zed-industries/zed (current stargazers_count=87054) linearly interpolated from repo creation 2021-02 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 31367293,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@openai/codex",
+            "as_of": "2026-04",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-04, retrieved live from the npm range API for @openai/codex."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 78902,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/openai/codex (current stargazers_count=98574) linearly interpolated from repo creation 2025-04 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "devin": {
+      "display_name": "Devin",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "continue": {
+      "display_name": "Continue",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 32162,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/continuedev/continue (current stargazers_count=34907) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=Continue.continue",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-04 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "claude-artifacts": {
+      "display_name": "Claude Artifacts",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcegraph-cody": {
+      "display_name": "Sourcegraph Cody",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "cline": {
+      "display_name": "Cline",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 56643,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/cline/cline (current stargazers_count=64709) linearly interpolated from repo creation 2024-07 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-04 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openhands": {
+      "display_name": "OpenHands",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 2132524,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/openhands-ai/overall",
+            "as_of": "2026-04",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-04 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 72288,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/All-Hands-AI/OpenHands (current stargazers_count=80932) linearly interpolated from repo creation 2024-03 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "jetbrains-ai-assistant": {
+      "display_name": "JetBrains AI Assistant",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "qodo-gen": {
+      "display_name": "Qodo Gen",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "coderabbit": {
+      "display_name": "CodeRabbit",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "snyk-code": {
+      "display_name": "Snyk Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 2484697,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/snyk",
+            "as_of": "2026-04",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-04, retrieved live from the npm range API for snyk."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 5483,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/snyk/cli (current stargazers_count=5613) linearly interpolated from repo creation 2015-10 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-04",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "microsoft-intellicode": {
+      "display_name": "Microsoft IntelliCode",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcery": {
+      "display_name": "Sourcery",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "diffblue-cover": {
+      "display_name": "Diffblue Cover",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    }
+  }
+}

--- a/data/historical-metrics/2026-05.json
+++ b/data/historical-metrics/2026-05.json
@@ -1,0 +1,529 @@
+{
+  "$schema": "historical-metrics-override/v1",
+  "period": "2026-05",
+  "reconstructed": true,
+  "generated_at": "2026-07-16T05:22:35.520Z",
+  "methodology_version": "1.0",
+  "notes": "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+  "fidelity_levels": {
+    "real": "Directly retrieved from an external time-series API for this exact calendar month.",
+    "interpolated": "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+    "held_flat": "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+    "not_applicable": "No value exists or is recoverable for this tool/metric/month."
+  },
+  "tools": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 34562178,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@anthropic-ai/claude-code",
+            "as_of": "2026-05",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-05, retrieved live from the npm range API for @anthropic-ai/claude-code."
+          }
+        },
+        "monthly_arr": {
+          "value": 8000000000,
+          "fidelity": "held_flat",
+          "source": "Claude Code ~$8B annualized run-rate by May 2026 (Sacra/Anthropic)",
+          "as_of": "2026-05",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2026-05). Not a real 2026-05 reading."
+        },
+        "swe_bench": {
+          "verified": {
+            "value": 74.5,
+            "fidelity": "held_flat",
+            "source": "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)",
+            "as_of": "2025-08",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-08). Not a real 2026-05 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "github-copilot": {
+      "display_name": "GitHub Copilot",
+      "metrics": {
+        "users": {
+          "value": 1800000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~1.8M users (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-09). Not a real 2026-05 reading."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~$400M ARR (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-09). Not a real 2026-05 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "cursor": {
+      "display_name": "Cursor",
+      "metrics": {
+        "users": {
+          "value": 897802,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Cursor ~360-400K paid users late 2025 (algorithm baseline)) and 2026-06 (Cursor ~1M users mid-2026 (estimate))",
+          "as_of": "estimated for 2026-05",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 3483333333,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Anysphere >$2B annualized run-rate by Feb 2026 (TechCrunch)) and 2026-06 (Cursor ~$4B annualized revenue by Jun 2026 (multiple))",
+          "as_of": "estimated for 2026-05",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "valuation": {
+          "value": 54770879121,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-12 (Anysphere ~$29.3B valuation (2025 round)) and 2026-06 (Cursor $60B valuation, SpaceX acquisition announced 2026-06-16)",
+          "as_of": "estimated for 2026-05",
+          "recovery_note": "valuation has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 300,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~300 employees 2026 (jobsbyculture)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-06). Not a real 2026-05 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "chatgpt-canvas": {
+      "display_name": "ChatGPT Canvas",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "v0": {
+      "display_name": "v0",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "kiro": {
+      "display_name": "Kiro",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "windsurf": {
+      "display_name": "Windsurf",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-jules": {
+      "display_name": "Google Jules",
+      "metrics": {
+        "swe_bench": {
+          "verified": {
+            "value": 52.2,
+            "fidelity": "held_flat",
+            "source": "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)",
+            "as_of": "2025-06",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-06). Not a real 2026-05 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "amazon-q-developer": {
+      "display_name": "Amazon Q Developer",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "lovable": {
+      "display_name": "Lovable",
+      "metrics": {
+        "users": {
+          "value": 7107473,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2025-09 (Lovable 140K users (uuid-mappings: lovable-achieves-5-56m-arr)) and 2026-06 (Lovable ~8M users 2026 (getpanto))",
+          "as_of": "estimated for 2026-05",
+          "recovery_note": "user count has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "monthly_arr": {
+          "value": 474166667,
+          "fidelity": "interpolated",
+          "source": "Linear interpolation between dated anchors 2026-02 (Lovable $400M ARR Feb 2026 (Bloomberg)) and 2026-06 (Lovable $500M annualized Jun 2026 (TechCrunch))",
+          "as_of": "estimated for 2026-05",
+          "recovery_note": "ARR has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required."
+        },
+        "employees": {
+          "value": 146,
+          "fidelity": "held_flat",
+          "source": "Lovable 146 employees (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-03). Not a real 2026-05 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "aider": {
+      "display_name": "Aider",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 942009,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/aider-chat/overall",
+            "as_of": "2026-05",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-05 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 44916,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/Aider-AI/aider (current stargazers_count=47416) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "tabnine": {
+      "display_name": "Tabnine",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "bolt-new": {
+      "display_name": "Bolt.new",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 14957,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/stackblitz/bolt.new (current stargazers_count=16460) linearly interpolated from repo creation 2024-09 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "monthly_arr": {
+          "value": 40000000,
+          "fidelity": "held_flat",
+          "source": "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)",
+          "as_of": "2025-08",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-08). Not a real 2026-05 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "augment-code": {
+      "display_name": "Augment Code",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-gemini-code-assist": {
+      "display_name": "Google Gemini Code Assist",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "replit-agent": {
+      "display_name": "Replit Agent",
+      "metrics": {
+        "users": {
+          "value": 50000000,
+          "fidelity": "held_flat",
+          "source": "Replit 50M+ users Mar 2026 (Sacra)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2026-03). Not a real 2026-05 reading."
+        },
+        "monthly_arr": {
+          "value": 525000000,
+          "fidelity": "held_flat",
+          "source": "Replit $525M annualized Apr 2026 (Forbes/Sacra)",
+          "as_of": "2026-04",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2026-04). Not a real 2026-05 reading."
+        },
+        "valuation": {
+          "value": 9000000000,
+          "fidelity": "held_flat",
+          "source": "Replit $9B valuation Mar 2026 (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for valuation; held flat at the nearest dated anchor (2026-03). Not a real 2026-05 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "zed": {
+      "display_name": "Zed",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 84367,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/zed-industries/zed (current stargazers_count=87054) linearly interpolated from repo creation 2021-02 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 239381470,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@openai/codex",
+            "as_of": "2026-05",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-05, retrieved live from the npm range API for @openai/codex."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 85388,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/openai/codex (current stargazers_count=98574) linearly interpolated from repo creation 2025-04 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "devin": {
+      "display_name": "Devin",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "continue": {
+      "display_name": "Continue",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 33067,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/continuedev/continue (current stargazers_count=34907) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=Continue.continue",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-05 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "claude-artifacts": {
+      "display_name": "Claude Artifacts",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcegraph-cody": {
+      "display_name": "Sourcegraph Cody",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "cline": {
+      "display_name": "Cline",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 59302,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/cline/cline (current stargazers_count=64709) linearly interpolated from repo creation 2024-07 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-05 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openhands": {
+      "display_name": "OpenHands",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 1005825,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/openhands-ai/overall",
+            "as_of": "2026-05",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-05 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 75138,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/All-Hands-AI/OpenHands (current stargazers_count=80932) linearly interpolated from repo creation 2024-03 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "jetbrains-ai-assistant": {
+      "display_name": "JetBrains AI Assistant",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "qodo-gen": {
+      "display_name": "Qodo Gen",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "coderabbit": {
+      "display_name": "CodeRabbit",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "snyk-code": {
+      "display_name": "Snyk Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 2559663,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/snyk",
+            "as_of": "2026-05",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-05, retrieved live from the npm range API for snyk."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 5526,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/snyk/cli (current stargazers_count=5613) linearly interpolated from repo creation 2015-10 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-05",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "microsoft-intellicode": {
+      "display_name": "Microsoft IntelliCode",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcery": {
+      "display_name": "Sourcery",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "diffblue-cover": {
+      "display_name": "Diffblue Cover",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    }
+  }
+}

--- a/data/historical-metrics/2026-05.json
+++ b/data/historical-metrics/2026-05.json
@@ -114,7 +114,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "v0": {
+    "v0-vercel": {
       "display_name": "v0",
       "metrics": {},
       "provenance": {
@@ -262,7 +262,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "google-gemini-code-assist": {
+    "gemini-code-assist": {
       "display_name": "Google Gemini Code Assist",
       "metrics": {},
       "provenance": {
@@ -353,7 +353,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "continue": {
+    "continue-dev": {
       "display_name": "Continue",
       "metrics": {
         "github": {
@@ -450,7 +450,7 @@
         "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
       }
     },
-    "jetbrains-ai-assistant": {
+    "jetbrains-ai": {
       "display_name": "JetBrains AI Assistant",
       "metrics": {},
       "provenance": {

--- a/data/historical-metrics/2026-06.json
+++ b/data/historical-metrics/2026-06.json
@@ -1,0 +1,529 @@
+{
+  "$schema": "historical-metrics-override/v1",
+  "period": "2026-06",
+  "reconstructed": true,
+  "generated_at": "2026-07-16T05:22:35.520Z",
+  "methodology_version": "1.0",
+  "notes": "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+  "fidelity_levels": {
+    "real": "Directly retrieved from an external time-series API for this exact calendar month.",
+    "interpolated": "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+    "held_flat": "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+    "not_applicable": "No value exists or is recoverable for this tool/metric/month."
+  },
+  "tools": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 44038610,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@anthropic-ai/claude-code",
+            "as_of": "2026-06",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-06, retrieved live from the npm range API for @anthropic-ai/claude-code."
+          }
+        },
+        "monthly_arr": {
+          "value": 8000000000,
+          "fidelity": "held_flat",
+          "source": "Claude Code ~$8B annualized run-rate by May 2026 (Sacra/Anthropic)",
+          "as_of": "2026-05",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2026-05). Not a real 2026-06 reading."
+        },
+        "swe_bench": {
+          "verified": {
+            "value": 74.5,
+            "fidelity": "held_flat",
+            "source": "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)",
+            "as_of": "2025-08",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-08). Not a real 2026-06 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "github-copilot": {
+      "display_name": "GitHub Copilot",
+      "metrics": {
+        "users": {
+          "value": 1800000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~1.8M users (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2025-09). Not a real 2026-06 reading."
+        },
+        "monthly_arr": {
+          "value": 400000000,
+          "fidelity": "held_flat",
+          "source": "GitHub Copilot ~$400M ARR (algorithm baseline)",
+          "as_of": "2025-09",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-09). Not a real 2026-06 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "cursor": {
+      "display_name": "Cursor",
+      "metrics": {
+        "users": {
+          "value": 1000000,
+          "fidelity": "held_flat",
+          "source": "Cursor ~1M users mid-2026 (estimate)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2026-06). Not a real 2026-06 reading."
+        },
+        "monthly_arr": {
+          "value": 4000000000,
+          "fidelity": "held_flat",
+          "source": "Cursor ~$4B annualized revenue by Jun 2026 (multiple)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2026-06). Not a real 2026-06 reading."
+        },
+        "valuation": {
+          "value": 60000000000,
+          "fidelity": "held_flat",
+          "source": "Cursor $60B valuation, SpaceX acquisition announced 2026-06-16",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for valuation; held flat at the nearest dated anchor (2026-06). Not a real 2026-06 reading."
+        },
+        "employees": {
+          "value": 300,
+          "fidelity": "held_flat",
+          "source": "Anysphere ~300 employees 2026 (jobsbyculture)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-06). Not a real 2026-06 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "chatgpt-canvas": {
+      "display_name": "ChatGPT Canvas",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "v0": {
+      "display_name": "v0",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "kiro": {
+      "display_name": "Kiro",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "windsurf": {
+      "display_name": "Windsurf",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-jules": {
+      "display_name": "Google Jules",
+      "metrics": {
+        "swe_bench": {
+          "verified": {
+            "value": 52.2,
+            "fidelity": "held_flat",
+            "source": "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)",
+            "as_of": "2025-06",
+            "recovery_note": "No time-series API for SWE-bench Verified; held flat at the nearest dated anchor (2025-06). Not a real 2026-06 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "amazon-q-developer": {
+      "display_name": "Amazon Q Developer",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "lovable": {
+      "display_name": "Lovable",
+      "metrics": {
+        "users": {
+          "value": 8000000,
+          "fidelity": "held_flat",
+          "source": "Lovable ~8M users 2026 (getpanto)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2026-06). Not a real 2026-06 reading."
+        },
+        "monthly_arr": {
+          "value": 500000000,
+          "fidelity": "held_flat",
+          "source": "Lovable $500M annualized Jun 2026 (TechCrunch)",
+          "as_of": "2026-06",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2026-06). Not a real 2026-06 reading."
+        },
+        "employees": {
+          "value": 146,
+          "fidelity": "held_flat",
+          "source": "Lovable 146 employees (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for employee count; held flat at the nearest dated anchor (2026-03). Not a real 2026-06 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "aider": {
+      "display_name": "Aider",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 902904,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/aider-chat/overall",
+            "as_of": "2026-06",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-06 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 46187,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/Aider-AI/aider (current stargazers_count=47416) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "tabnine": {
+      "display_name": "Tabnine",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "bolt-new": {
+      "display_name": "Bolt.new",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 15721,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/stackblitz/bolt.new (current stargazers_count=16460) linearly interpolated from repo creation 2024-09 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "monthly_arr": {
+          "value": 40000000,
+          "fidelity": "held_flat",
+          "source": "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)",
+          "as_of": "2025-08",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2025-08). Not a real 2026-06 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "augment-code": {
+      "display_name": "Augment Code",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "google-gemini-code-assist": {
+      "display_name": "Google Gemini Code Assist",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "replit-agent": {
+      "display_name": "Replit Agent",
+      "metrics": {
+        "users": {
+          "value": 50000000,
+          "fidelity": "held_flat",
+          "source": "Replit 50M+ users Mar 2026 (Sacra)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for user count; held flat at the nearest dated anchor (2026-03). Not a real 2026-06 reading."
+        },
+        "monthly_arr": {
+          "value": 525000000,
+          "fidelity": "held_flat",
+          "source": "Replit $525M annualized Apr 2026 (Forbes/Sacra)",
+          "as_of": "2026-04",
+          "recovery_note": "No time-series API for ARR; held flat at the nearest dated anchor (2026-04). Not a real 2026-06 reading."
+        },
+        "valuation": {
+          "value": 9000000000,
+          "fidelity": "held_flat",
+          "source": "Replit $9B valuation Mar 2026 (TechCrunch)",
+          "as_of": "2026-03",
+          "recovery_note": "No time-series API for valuation; held flat at the nearest dated anchor (2026-03). Not a real 2026-06 reading."
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "zed": {
+      "display_name": "Zed",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 85732,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/zed-industries/zed (current stargazers_count=87054) linearly interpolated from repo creation 2021-02 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 46157876,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/@openai/codex",
+            "as_of": "2026-06",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-06, retrieved live from the npm range API for @openai/codex."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 92089,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/openai/codex (current stargazers_count=98574) linearly interpolated from repo creation 2025-04 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "devin": {
+      "display_name": "Devin",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "continue": {
+      "display_name": "Continue",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 34002,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/continuedev/continue (current stargazers_count=34907) linearly interpolated from repo creation 2023-05 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=Continue.continue",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-06 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "claude-artifacts": {
+      "display_name": "Claude Artifacts",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcegraph-cody": {
+      "display_name": "Sourcegraph Cody",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "cline": {
+      "display_name": "Cline",
+      "metrics": {
+        "github": {
+          "stars": {
+            "value": 62050,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/cline/cline (current stargazers_count=64709) linearly interpolated from repo creation 2024-07 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        },
+        "vscode": {
+          "installs": {
+            "value": null,
+            "fidelity": "held_flat",
+            "source": "https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev",
+            "as_of": null,
+            "recovery_note": "The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a 2026-06 reading."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "low-medium",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "openhands": {
+      "display_name": "OpenHands",
+      "metrics": {
+        "pypi": {
+          "downloads_last_month": {
+            "value": 6233062,
+            "fidelity": "real",
+            "source": "https://pypistats.org/api/packages/openhands-ai/overall",
+            "as_of": "2026-06",
+            "recovery_note": "Sum of daily PyPI downloads for 2026-06 from the pypistats overall series (mirrors excluded)."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 78082,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/All-Hands-AI/OpenHands (current stargazers_count=80932) linearly interpolated from repo creation 2024-03 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "jetbrains-ai-assistant": {
+      "display_name": "JetBrains AI Assistant",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "qodo-gen": {
+      "display_name": "Qodo Gen",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "coderabbit": {
+      "display_name": "CodeRabbit",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "snyk-code": {
+      "display_name": "Snyk Code",
+      "metrics": {
+        "npm": {
+          "downloads_last_month": {
+            "value": 2634057,
+            "fidelity": "real",
+            "source": "https://api.npmjs.org/downloads/range/2025-12-01:2026-06-30/snyk",
+            "as_of": "2026-06",
+            "recovery_note": "Sum of daily npm downloads for calendar month 2026-06, retrieved live from the npm range API for snyk."
+          }
+        },
+        "github": {
+          "stars": {
+            "value": 5570,
+            "fidelity": "interpolated",
+            "source": "https://api.github.com/repos/snyk/cli (current stargazers_count=5613) linearly interpolated from repo creation 2015-10 (0 stars) to 2026-07",
+            "as_of": "estimated for 2026-06",
+            "recovery_note": "GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate."
+          }
+        }
+      },
+      "provenance": {
+        "overall_confidence": "medium-high",
+        "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
+      }
+    },
+    "microsoft-intellicode": {
+      "display_name": "Microsoft IntelliCode",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "sourcery": {
+      "display_name": "Sourcery",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    },
+    "diffblue-cover": {
+      "display_name": "Diffblue Cover",
+      "metrics": {},
+      "provenance": {
+        "overall_confidence": "none",
+        "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
+      }
+    }
+  }
+}

--- a/data/historical-metrics/2026-06.json
+++ b/data/historical-metrics/2026-06.json
@@ -114,7 +114,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "v0": {
+    "v0-vercel": {
       "display_name": "v0",
       "metrics": {},
       "provenance": {
@@ -262,7 +262,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "google-gemini-code-assist": {
+    "gemini-code-assist": {
       "display_name": "Google Gemini Code Assist",
       "metrics": {},
       "provenance": {
@@ -353,7 +353,7 @@
         "notes": "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production."
       }
     },
-    "continue": {
+    "continue-dev": {
       "display_name": "Continue",
       "metrics": {
         "github": {
@@ -450,7 +450,7 @@
         "notes": "Reconstructed metrics; see per-leaf fidelity/source/recovery_note."
       }
     },
-    "jetbrains-ai-assistant": {
+    "jetbrains-ai": {
       "display_name": "JetBrains AI Assistant",
       "metrics": {},
       "provenance": {

--- a/lib/historical-metrics/slugify.ts
+++ b/lib/historical-metrics/slugify.ts
@@ -1,0 +1,18 @@
+/**
+ * Slug derivation for the historical-metrics backfill.
+ *
+ * Why: the override files key each tool by its `slug`, and
+ * `applyHistoricalMetricsOverride` matches on `tool.slug`. Both the generator
+ * (which writes the files) and the dry-run roster (which reads them) must derive
+ * slugs identically, so the rule lives here in one place.
+ *
+ * The rule matches the project's existing slug convention (see the placeholder
+ * `data/json/tools/tools.json`: "GitHub Copilot" -> "github-copilot",
+ * "Cursor" -> "cursor") and the validated POC ("Claude Code" -> "claude-code").
+ */
+export function slugify(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/lib/historical-metrics/slugify.ts
+++ b/lib/historical-metrics/slugify.ts
@@ -16,3 +16,35 @@ export function slugify(name: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
+
+/**
+ * SLUG ALIAS MAP — display-name-derived slug -> live `tools.slug` override.
+ *
+ * `slugify(display_name)` is a best-effort derivation and does not always match
+ * the live slug stored in the `tools` table: some live slugs carry a
+ * disambiguating suffix (e.g. a vendor or product-line qualifier) that cannot be
+ * recovered from the display name alone. A publish-time dry-check compares
+ * override-file keys against live `tools.slug` values; every mismatch it finds
+ * must be added here so regenerating the historical-metrics files keeps
+ * producing keys the live loader (`applyHistoricalMetricsOverride`, which
+ * matches on `tool.slug`) will actually match.
+ *
+ * Keep this list flat, alphabetized by derived slug, and append-only — never
+ * repurpose an existing key for a different tool.
+ */
+export const SLUG_ALIASES: Record<string, string> = {
+  continue: "continue-dev",
+  "google-gemini-code-assist": "gemini-code-assist",
+  "jetbrains-ai-assistant": "jetbrains-ai",
+  v0: "v0-vercel",
+};
+
+/**
+ * Resolves a display-name-derived slug to the live `tools.slug` value that
+ * should be used as the override-file key, applying `SLUG_ALIASES` when the
+ * derived slug is a known mismatch. Returns the derived slug unchanged
+ * otherwise.
+ */
+export function resolveLiveSlug(derivedSlug: string): string {
+  return SLUG_ALIASES[derivedSlug] ?? derivedSlug;
+}

--- a/lib/historical-metrics/timeseries.test.ts
+++ b/lib/historical-metrics/timeseries.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  interpolateMonthly,
+  periodToTime,
+  sumMonthlyDownloads,
+  type DailyDownload,
+} from "./timeseries";
+
+const days: DailyDownload[] = [
+  { day: "2025-11-30", downloads: 100 }, // out of window (Nov)
+  { day: "2025-12-01", downloads: 10 },
+  { day: "2025-12-15", downloads: 20 },
+  { day: "2025-12-31", downloads: 30 },
+  { day: "2026-01-01", downloads: 5 },
+  { day: "2026-01-02", downloads: 7 },
+];
+
+describe("sumMonthlyDownloads", () => {
+  it("sums only the days within the target calendar month", () => {
+    expect(sumMonthlyDownloads(days, "2025-12")).toBe(60);
+    expect(sumMonthlyDownloads(days, "2026-01")).toBe(12);
+  });
+
+  it("returns 0 for a month with no matching days", () => {
+    expect(sumMonthlyDownloads(days, "2026-05")).toBe(0);
+  });
+
+  it("ignores malformed entries and coerces non-numbers to 0", () => {
+    const messy = [
+      { day: "2026-02-01", downloads: 4 },
+      { day: "2026-02-02", downloads: Number.NaN },
+      { day: undefined as unknown as string, downloads: 9 },
+    ];
+    expect(sumMonthlyDownloads(messy, "2026-02")).toBe(4);
+  });
+
+  it("rejects a malformed period argument", () => {
+    expect(() => sumMonthlyDownloads(days, "2026")).toThrow(/YYYY-MM/);
+    expect(() => sumMonthlyDownloads(days, "Dec-2025")).toThrow();
+  });
+});
+
+describe("periodToTime", () => {
+  it("maps a period to the first-of-month UTC timestamp", () => {
+    expect(periodToTime("2026-01")).toBe(Date.UTC(2026, 0, 1));
+    expect(periodToTime("2025-12")).toBe(Date.UTC(2025, 11, 1));
+  });
+});
+
+describe("interpolateMonthly", () => {
+  it("returns the exact endpoints at the anchor months", () => {
+    expect(interpolateMonthly(0, "2026-01", 600, "2026-07", "2026-01")).toBe(0);
+    expect(interpolateMonthly(0, "2026-01", 600, "2026-07", "2026-07")).toBe(600);
+  });
+
+  it("linearly interpolates by calendar days between anchors", () => {
+    // 100 -> 400 from Jan 1 to Jul 1 (181 days); Apr 1 is 90 days in
+    // => 100 + 300 * (90/181) = 249.17 -> 249 (day-weighted, not month-count).
+    expect(interpolateMonthly(100, "2026-01", 400, "2026-07", "2026-04")).toBe(249);
+  });
+
+  it("clamps below the start and above the end anchors", () => {
+    expect(interpolateMonthly(100, "2026-03", 400, "2026-06", "2026-01")).toBe(100);
+    expect(interpolateMonthly(100, "2026-03", 400, "2026-06", "2026-12")).toBe(400);
+  });
+
+  it("handles equal anchors without dividing by zero", () => {
+    expect(interpolateMonthly(50, "2026-03", 90, "2026-03", "2026-03")).toBe(90);
+  });
+
+  it("rounds to an integer", () => {
+    // 0 -> 100 from Jan 1 to Apr 1 (90 days); Feb 1 is 31 days in
+    // => 100 * (31/90) = 34.44 -> 34.
+    expect(interpolateMonthly(0, "2026-01", 100, "2026-04", "2026-02")).toBe(34);
+  });
+});

--- a/lib/historical-metrics/timeseries.ts
+++ b/lib/historical-metrics/timeseries.ts
@@ -1,0 +1,75 @@
+/**
+ * Pure time-series helpers for the historical-metrics generator.
+ *
+ * These are deliberately dependency-free and side-effect-free so they can be
+ * unit-tested directly (see timeseries.test.ts). The generator script imports
+ * them; all network I/O lives in the script, not here.
+ */
+
+/** A single day of npm/PyPI downloads as returned by the range APIs. */
+export interface DailyDownload {
+  day: string; // "YYYY-MM-DD"
+  downloads: number;
+}
+
+/**
+ * Sum the daily downloads that fall within a given calendar month.
+ *
+ * The npm range API (`api.npmjs.org/downloads/range/<start>:<end>/<pkg>`) returns
+ * a flat array of `{ day, downloads }` spanning an arbitrary range; to get a
+ * tool's "downloads_last_month" for period "YYYY-MM" we sum every day whose
+ * `day` begins with that period prefix.
+ *
+ * @param days   Daily download records (any range; extra days are ignored).
+ * @param period Target month as "YYYY-MM".
+ * @returns Total downloads for that month (0 if no matching days).
+ */
+export function sumMonthlyDownloads(days: DailyDownload[], period: string): number {
+  if (!/^\d{4}-\d{2}$/.test(period)) {
+    throw new Error(`sumMonthlyDownloads: period must be "YYYY-MM", got "${period}"`);
+  }
+  const prefix = `${period}-`;
+  let total = 0;
+  for (const d of days) {
+    if (typeof d?.day === "string" && d.day.startsWith(prefix)) {
+      total += Number(d.downloads) || 0;
+    }
+  }
+  return total;
+}
+
+/** First-of-month UTC timestamp (ms) for a "YYYY-MM" period. */
+export function periodToTime(period: string): number {
+  const [y, m] = period.split("-").map(Number);
+  return Date.UTC(y, m - 1, 1);
+}
+
+/**
+ * Linear interpolation of a monotone-ish metric (e.g. GitHub stars, user count)
+ * between two dated anchor points, evaluated at the first day of `period`.
+ *
+ * Clamps to the endpoints outside the anchor window so an interpolated value is
+ * never extrapolated past a known real reading. Values are rounded to integers.
+ *
+ * @param startValue Value at `startPeriod`.
+ * @param startPeriod "YYYY-MM" of the start anchor.
+ * @param endValue   Value at `endPeriod`.
+ * @param endPeriod  "YYYY-MM" of the end anchor.
+ * @param period     Target "YYYY-MM".
+ */
+export function interpolateMonthly(
+  startValue: number,
+  startPeriod: string,
+  endValue: number,
+  endPeriod: string,
+  period: string
+): number {
+  const t0 = periodToTime(startPeriod);
+  const t1 = periodToTime(endPeriod);
+  const t = periodToTime(period);
+
+  if (t1 === t0) return Math.round(endValue);
+  const frac = (t - t0) / (t1 - t0);
+  const clamped = Math.max(0, Math.min(1, frac));
+  return Math.round(startValue + (endValue - startValue) * clamped);
+}

--- a/lib/services/apply-historical-metrics-override.test.ts
+++ b/lib/services/apply-historical-metrics-override.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyHistoricalMetricsOverride,
+  computeRankings,
+  type HistoricalMetricsOverride,
+  type RankingSourceTool,
+} from "./ranking-generation.service";
+
+function tool(
+  id: string,
+  slug: string,
+  data: Record<string, unknown> | null = { metrics: {} }
+): RankingSourceTool {
+  return { id, name: slug, slug, category: "code-editor", status: "active", data };
+}
+
+const overrides: HistoricalMetricsOverride = {
+  period: "2026-03",
+  reconstructed: true,
+  tools: {
+    "claude-code": {
+      display_name: "Claude Code",
+      metrics: {
+        npm: { downloads_last_month: { value: 42_617_911, fidelity: "real", source: "npm", as_of: "2026-03", recovery_note: "n" } },
+        monthly_arr: { value: 2_500_000_000, fidelity: "interpolated", source: "s", as_of: "2026-03", recovery_note: "n" },
+        swe_bench: { verified: { value: 74.5, fidelity: "held_flat", source: "s", as_of: "2025-08", recovery_note: "n" } },
+      },
+      provenance: { overall_confidence: "medium-high" },
+    },
+    aider: {
+      metrics: {
+        github: { stars: { value: 44_800, fidelity: "interpolated", source: "gh", as_of: "2026-03", recovery_note: "n" } },
+      },
+    },
+  },
+};
+
+describe("applyHistoricalMetricsOverride", () => {
+  it("deep-merges numeric .value leaves into the exact engine metric paths", () => {
+    const [claude] = applyHistoricalMetricsOverride([tool("4", "claude-code")], overrides);
+    const metrics = (claude!.data as { metrics: Record<string, unknown> }).metrics as Record<string, unknown>;
+
+    // Nested container leaves flattened to their .value.
+    expect((metrics.npm as Record<string, unknown>).downloads_last_month).toBe(42_617_911);
+    expect((metrics.swe_bench as Record<string, unknown>).verified).toBe(74.5);
+    // Flat leaf.
+    expect(metrics.monthly_arr).toBe(2_500_000_000);
+  });
+
+  it("stamps __reconstructed and a __provenance block on matched tools", () => {
+    const [claude] = applyHistoricalMetricsOverride([tool("4", "claude-code")], overrides);
+    const data = claude!.data as Record<string, unknown>;
+    expect(data.__reconstructed).toBe(true);
+    expect(data.__provenance).toMatchObject({ period: "2026-03", reconstructed: true, overall_confidence: "medium-high" });
+  });
+
+  it("passes non-matching tools through untouched (same reference)", () => {
+    const other = tool("99", "not-in-override");
+    const [result] = applyHistoricalMetricsOverride([other], overrides);
+    expect(result).toBe(other); // referential identity => byte-for-byte unchanged
+    expect((result!.data as Record<string, unknown>).__reconstructed).toBeUndefined();
+  });
+
+  it("does not mutate the input tool for matched tools", () => {
+    const input = tool("4", "claude-code");
+    applyHistoricalMetricsOverride([input], overrides);
+    expect((input.data as { metrics: Record<string, unknown> }).metrics).toEqual({});
+    expect((input.data as Record<string, unknown>).__reconstructed).toBeUndefined();
+  });
+
+  it("preserves existing base metrics not named in the override", () => {
+    const base = tool("4", "claude-code", { metrics: { users: 850_000, github: { stars: 1 } } });
+    const [claude] = applyHistoricalMetricsOverride([base], overrides);
+    const metrics = (claude!.data as { metrics: Record<string, unknown> }).metrics;
+    // untouched base value survives the merge
+    expect(metrics.users).toBe(850_000);
+    // overridden branch is applied
+    expect((metrics.npm as Record<string, unknown>).downloads_last_month).toBe(42_617_911);
+  });
+
+  it("handles a null base data object without throwing", () => {
+    const [claude] = applyHistoricalMetricsOverride([tool("4", "claude-code", null)], overrides);
+    const metrics = (claude!.data as { metrics: Record<string, unknown> }).metrics;
+    expect((metrics.npm as Record<string, unknown>).downloads_last_month).toBe(42_617_911);
+  });
+
+  it("makes computeRankings surface reconstructed + provenance on scored rows", () => {
+    const applied = applyHistoricalMetricsOverride(
+      [tool("4", "claude-code"), tool("99", "not-in-override")],
+      overrides
+    );
+    const rows = computeRankings(applied, new Map(), new Date("2026-03-01T00:00:00Z"));
+    const claudeRow = rows.find((r) => r.tool_slug === "claude-code")!;
+    const otherRow = rows.find((r) => r.tool_slug === "not-in-override")!;
+
+    expect(claudeRow.reconstructed).toBe(true);
+    expect(claudeRow.provenance).toMatchObject({ period: "2026-03" });
+    // Untouched tool has neither field (keeps live-path snapshots identical).
+    expect(otherRow.reconstructed).toBeUndefined();
+    expect(otherRow.provenance).toBeUndefined();
+  });
+
+  it("is a no-op when the override has an empty tools map", () => {
+    const t = tool("1", "cursor");
+    const [result] = applyHistoricalMetricsOverride([t], { tools: {} });
+    expect(result).toBe(t);
+  });
+});

--- a/lib/services/ranking-generation.service.ts
+++ b/lib/services/ranking-generation.service.ts
@@ -19,6 +19,7 @@
  *   `rankings_period_idx` index is the durable backstop across instances.
  */
 
+import { existsSync, readFileSync } from "node:fs";
 import { eq } from "drizzle-orm";
 import { getDb } from "@/lib/db/connection";
 import { rankings, tools } from "@/lib/db/schema";
@@ -52,6 +53,17 @@ export interface RankingEntry {
     change: number;
     direction: "up" | "down" | "same";
   };
+  /**
+   * True when this row was scored from a period-specific historical metrics
+   * override file rather than the live `tools.data`. Absent on live cron runs.
+   */
+  reconstructed?: boolean;
+  /**
+   * Provenance block carried through from the override file (period + per-tool
+   * fidelity notes). Persisted alongside the row in the existing `rankings.data`
+   * JSONB; never populated on live cron runs. No schema migration required.
+   */
+  provenance?: Record<string, unknown>;
 }
 
 /** Summary returned to callers (cron route surfaces this as JSON). */
@@ -82,6 +94,14 @@ export interface RegenerateRankingsOptions {
   persistence?: RankingPersistencePort;
   /** Clock injection for deterministic tests. */
   now?: () => Date;
+  /**
+   * Optional path to a `data/historical-metrics/<period>.json` override file.
+   * When set AND the file exists, the loaded tools' `data.metrics.*` are merged
+   * with the reconstructed period-specific values before scoring (additive
+   * historical-backfill path). When unset or the file is missing, the live
+   * `tools.data` is scored unchanged — the cron path is byte-for-byte identical.
+   */
+  metricsOverridePath?: string;
 }
 
 /** Raised when a regeneration for the same period is already in flight. */
@@ -166,8 +186,9 @@ export function computeRankings(
     const rank = index + 1;
     const prevRank = previousRankMap.get(entry.tool.id);
     const change = prevRank ? prevRank - rank : 0;
+    const toolData = entry.tool.data as Record<string, unknown> | null;
 
-    return {
+    const row: RankingEntry = {
       tool_id: entry.tool.id,
       tool_name: entry.tool.name,
       tool_slug: entry.tool.slug,
@@ -183,6 +204,122 @@ export function computeRankings(
         direction: change > 0 ? "up" : change < 0 ? "down" : "same",
       },
     };
+
+    // Only stamp reconstruction fields when the tool was scored from an override
+    // file (applyHistoricalMetricsOverride sets `__reconstructed`). Left absent
+    // on the live path so persisted snapshots are unchanged there.
+    if (toolData?.["__reconstructed"] === true) {
+      row.reconstructed = true;
+      const provenance = toolData["__provenance"];
+      if (provenance && typeof provenance === "object") {
+        row.provenance = provenance as Record<string, unknown>;
+      }
+    }
+
+    return row;
+  });
+}
+
+/** A single reconstructed metric leaf in a historical override file. */
+export interface HistoricalMetricLeaf {
+  /** The numeric value the engine scores (null = intentionally not applicable). */
+  value: number | null;
+  fidelity?: "real" | "interpolated" | "held_flat" | "not_applicable";
+  source?: string | null;
+  as_of?: string | null;
+  recovery_note?: string;
+}
+
+/** Shape of a `data/historical-metrics/<period>.json` override file. */
+export interface HistoricalMetricsOverride {
+  period?: string;
+  reconstructed?: boolean;
+  tools: Record<
+    string,
+    {
+      display_name?: string;
+      /** Nested tree of metric leaves / containers (npm, github, pypi, users, …). */
+      metrics?: Record<string, unknown>;
+      provenance?: Record<string, unknown>;
+    }
+  >;
+  [key: string]: unknown;
+}
+
+/**
+ * Recursively copy the numeric `.value` leaves from an override subtree into the
+ * matching path of a target metrics object, preserving nesting. A node is a leaf
+ * when it carries a `value` property (e.g. `{ value, fidelity, source, … }`);
+ * otherwise it is a container (e.g. `npm`, `github`) and we recurse. Existing
+ * target values not named in the override are left untouched (deep merge).
+ */
+function mergeOverrideLeaves(
+  target: Record<string, unknown>,
+  override: Record<string, unknown>
+): void {
+  for (const [key, node] of Object.entries(override)) {
+    if (!node || typeof node !== "object") continue;
+    if ("value" in (node as Record<string, unknown>)) {
+      // Leaf: extract only the scored `.value` (may be null); provenance stays
+      // in the override file, not in the scored metrics tree.
+      target[key] = (node as HistoricalMetricLeaf).value;
+    } else {
+      const existing = target[key];
+      const child =
+        existing && typeof existing === "object"
+          ? (existing as Record<string, unknown>)
+          : {};
+      target[key] = child;
+      mergeOverrideLeaves(child, node as Record<string, unknown>);
+    }
+  }
+}
+
+/**
+ * PURE: apply a period-specific historical metrics override onto a set of source
+ * tools. For every tool whose `slug` matches a key in `overrides.tools`, the
+ * override's numeric `.value` leaves are deep-merged into `tool.data.metrics.*`
+ * (the exact paths the v7.6 engine reads) and the tool is flagged with
+ * `data.__reconstructed = true` (plus a `__provenance` block). Tools with no
+ * matching override key are returned by reference, completely untouched, so the
+ * live scoring path is unaffected when an override file omits a tool.
+ *
+ * Does not mutate the input array or its tools (returns fresh clones for matched
+ * tools) — safe to unit test directly.
+ */
+export function applyHistoricalMetricsOverride(
+  sourceTools: RankingSourceTool[],
+  overrides: HistoricalMetricsOverride
+): RankingSourceTool[] {
+  const overrideMap = overrides?.tools ?? {};
+
+  return sourceTools.map((tool) => {
+    const toolOverride = overrideMap[tool.slug];
+    if (!toolOverride) return tool; // untouched pass-through
+
+    const cloned = structuredClone(tool);
+    const data = (cloned.data ?? {}) as Record<string, unknown>;
+    cloned.data = data;
+
+    const existingMetrics = data["metrics"];
+    const metrics =
+      existingMetrics && typeof existingMetrics === "object"
+        ? (existingMetrics as Record<string, unknown>)
+        : {};
+    data["metrics"] = metrics;
+
+    if (toolOverride.metrics) {
+      mergeOverrideLeaves(metrics, toolOverride.metrics);
+    }
+
+    data["__reconstructed"] = true;
+    data["__provenance"] = {
+      period: overrides.period,
+      reconstructed: overrides.reconstructed ?? true,
+      ...(toolOverride.provenance ?? {}),
+    };
+
+    return cloned;
   });
 }
 
@@ -259,10 +396,21 @@ export async function regenerateRankings(
   inFlightPeriods.add(period);
 
   try {
-    const [sourceTools, prevSnapshot] = await Promise.all([
+    const [loadedTools, prevSnapshot] = await Promise.all([
       persistence.loadActiveTools(),
       persistence.loadCurrentRankings(),
     ]);
+
+    // Additive historical-backfill path: if a period-specific override file is
+    // provided AND exists on disk, score the reconstructed metrics instead of
+    // the live `tools.data`. Otherwise the live tools are scored unchanged.
+    let sourceTools = loadedTools;
+    if (options.metricsOverridePath && existsSync(options.metricsOverridePath)) {
+      const overrides = JSON.parse(
+        readFileSync(options.metricsOverridePath, "utf8")
+      ) as HistoricalMetricsOverride;
+      sourceTools = applyHistoricalMetricsOverride(loadedTools, overrides);
+    }
 
     const previousRankMap = buildPreviousRankMap(prevSnapshot?.data ?? null);
     const data = computeRankings(sourceTools, previousRankMap, publishedAt);

--- a/scripts/generate-historical-metrics.ts
+++ b/scripts/generate-historical-metrics.ts
@@ -31,7 +31,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { slugify } from "@/lib/historical-metrics/slugify";
+import { resolveLiveSlug, slugify } from "@/lib/historical-metrics/slugify";
 import {
   interpolateMonthly,
   periodToTime,
@@ -302,18 +302,30 @@ function anchorLeaf(anchors: Anchor[], period: string, metricLabel: string): Lea
 interface RosterEntry {
   tool_id: string;
   name: string;
+  /** Display-name-derived slug; used to key the SOURCES table above. */
   slug: string;
+  /**
+   * Live `tools.slug` value used as the override-file key: `slug` run through
+   * `resolveLiveSlug` (see lib/historical-metrics/slugify.ts) so it matches
+   * `applyHistoricalMetricsOverride`'s lookup even when the live slug carries a
+   * suffix the display name can't reproduce.
+   */
+  overrideKey: string;
 }
 
 function loadRoster(): RosterEntry[] {
   const raw = JSON.parse(readFileSync(ROSTER_PATH, "utf8")) as {
     rankings: Array<{ tool_id: string; tool_name: string }>;
   };
-  return raw.rankings.map((r) => ({
-    tool_id: String(r.tool_id),
-    name: r.tool_name,
-    slug: slugify(r.tool_name),
-  }));
+  return raw.rankings.map((r) => {
+    const slug = slugify(r.tool_name);
+    return {
+      tool_id: String(r.tool_id),
+      name: r.tool_name,
+      slug,
+      overrideKey: resolveLiveSlug(slug),
+    };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -526,7 +538,7 @@ async function main() {
         // No substantiated data for this tool this month: emit an empty metrics
         // block so the file documents the full roster, but the loader will merge
         // nothing (production keeps the live tools.data value).
-        tools[entry.slug] = {
+        tools[entry.overrideKey] = {
           display_name: entry.name,
           metrics: {},
           provenance: {
@@ -536,7 +548,7 @@ async function main() {
         };
         continue;
       }
-      tools[entry.slug] = {
+      tools[entry.overrideKey] = {
         display_name: entry.name,
         metrics,
         provenance: {

--- a/scripts/generate-historical-metrics.ts
+++ b/scripts/generate-historical-metrics.ts
@@ -1,0 +1,590 @@
+#!/usr/bin/env tsx
+/**
+ * Generate research-augmented historical metrics override files.
+ *
+ * Produces one `data/historical-metrics/<period>.json` per month of the backfill
+ * gap (Dec 2025 -> Jun 2026). Each file supplies PERIOD-SPECIFIC reconstructed
+ * metrics for the v7.6 ranking engine so the "Historical AI Tool Rankings" chart
+ * shows genuine movement instead of a duplicated flat line.
+ *
+ * Data recovery (per the proven design):
+ *   - npm  downloads_last_month : REAL   -> summed from api.npmjs.org range API.
+ *   - PyPI downloads_last_month : REAL where the rolling window still covers the
+ *                                 month; otherwise held_flat / not_applicable.
+ *   - GitHub stars              : INTERPOLATED between repo creation (0) and the
+ *                                 current total (linear; documented estimate).
+ *   - users/arr/valuation/…     : INTERPOLATED between dated news anchors (mined
+ *                                 from data/uuid-mappings.json + web research),
+ *                                 else held_flat with an explicit assumption.
+ *   - swe_bench                 : step function at release events.
+ *
+ * Every leaf carries {value, fidelity, source, as_of, recovery_note}. The loader
+ * (applyHistoricalMetricsOverride) extracts `.value`; the rest is persisted
+ * provenance. Re-runnable and idempotent: each run overwrites the files and logs
+ * a per-metric fidelity breakdown.
+ *
+ * This script performs NO database access and writes only JSON files. Usage:
+ *   npx tsx scripts/generate-historical-metrics.ts
+ *   npx tsx scripts/generate-historical-metrics.ts --only=2026-03
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { slugify } from "@/lib/historical-metrics/slugify";
+import {
+  interpolateMonthly,
+  periodToTime,
+  sumMonthlyDownloads,
+  type DailyDownload,
+} from "@/lib/historical-metrics/timeseries";
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const OUT_DIR = join(ROOT, "data", "historical-metrics");
+const ROSTER_PATH = join(ROOT, "data", "extracted-rankings", "2025-09.json");
+
+/** The backfill gap: Dec 2025 through Jun 2026 (inclusive). */
+const PERIODS = [
+  "2025-12",
+  "2026-01",
+  "2026-02",
+  "2026-03",
+  "2026-04",
+  "2026-05",
+  "2026-06",
+];
+
+/** npm range covering the whole gap window (one call per package). */
+const NPM_RANGE_START = "2025-12-01";
+const NPM_RANGE_END = "2026-06-30";
+
+/** "now" anchor used as the end point for GitHub-star interpolation. */
+const CURRENT_PERIOD = "2026-07";
+
+type Fidelity = "real" | "interpolated" | "held_flat" | "not_applicable";
+
+interface Leaf {
+  value: number | null;
+  fidelity: Fidelity;
+  source: string | null;
+  as_of: string | null;
+  recovery_note: string;
+}
+
+interface Anchor {
+  period: string; // "YYYY-MM"
+  value: number;
+  source: string;
+}
+
+interface ToolSource {
+  npm?: string;
+  pypi?: string;
+  github?: string; // "owner/repo"
+  vscode?: string; // marketplace itemName (documented gap; value stays null)
+  anchors?: Partial<
+    Record<
+      "users" | "monthly_arr" | "valuation" | "funding" | "employees" | "swe_bench_verified",
+      Anchor[]
+    >
+  >;
+}
+
+/**
+ * Per-tool source mapping (keyed by slug = slugify(display name)).
+ * npm/pypi/github were probe-verified to resolve; anchors were mined from
+ * data/uuid-mappings.json and dated 2026 news (TechCrunch/Bloomberg/Sacra/etc).
+ * Tools absent from this table (or metrics absent for a tool) are intentionally
+ * left to the live `tools.data` value in production — we only emit leaves we can
+ * substantiate.
+ */
+const SOURCES: Record<string, ToolSource> = {
+  "claude-code": {
+    npm: "@anthropic-ai/claude-code",
+    anchors: {
+      monthly_arr: [
+        { period: "2025-12", value: 1_000_000_000, source: "Anthropic: Claude Code hit $1B annualized within ~6 months of mid-2025 launch" },
+        { period: "2026-02", value: 2_500_000_000, source: "Claude Code run-rate >$2.5B by Feb 2026 (VentureBeat/Sacra)" },
+        { period: "2026-05", value: 8_000_000_000, source: "Claude Code ~$8B annualized run-rate by May 2026 (Sacra/Anthropic)" },
+      ],
+      swe_bench_verified: [
+        { period: "2025-08", value: 74.5, source: "Claude Opus 4.1 SWE-bench Verified 74.5% (uuid-mappings: anthropic-releases-claude-opus-4-1)" },
+      ],
+    },
+  },
+  cursor: {
+    anchors: {
+      monthly_arr: [
+        { period: "2025-12", value: 1_000_000_000, source: "Cursor crossed $1B ARR late 2025 (TechCrunch)" },
+        { period: "2026-02", value: 2_000_000_000, source: "Anysphere >$2B annualized run-rate by Feb 2026 (TechCrunch)" },
+        { period: "2026-06", value: 4_000_000_000, source: "Cursor ~$4B annualized revenue by Jun 2026 (multiple)" },
+      ],
+      valuation: [
+        { period: "2025-12", value: 29_300_000_000, source: "Anysphere ~$29.3B valuation (2025 round)" },
+        { period: "2026-06", value: 60_000_000_000, source: "Cursor $60B valuation, SpaceX acquisition announced 2026-06-16" },
+      ],
+      users: [
+        { period: "2025-12", value: 400_000, source: "Cursor ~360-400K paid users late 2025 (algorithm baseline)" },
+        { period: "2026-06", value: 1_000_000, source: "Cursor ~1M users mid-2026 (estimate)" },
+      ],
+      employees: [{ period: "2026-06", value: 300, source: "Anysphere ~300 employees 2026 (jobsbyculture)" }],
+    },
+  },
+  "github-copilot": {
+    anchors: {
+      monthly_arr: [{ period: "2025-09", value: 400_000_000, source: "GitHub Copilot ~$400M ARR (algorithm baseline)" }],
+      users: [{ period: "2025-09", value: 1_800_000, source: "GitHub Copilot ~1.8M users (algorithm baseline)" }],
+    },
+  },
+  lovable: {
+    anchors: {
+      monthly_arr: [
+        { period: "2025-11", value: 200_000_000, source: "Lovable $200M ARR Nov 2025 (TechCrunch)" },
+        { period: "2026-01", value: 300_000_000, source: "Lovable $300M ARR Jan 2026 (TechCrunch)" },
+        { period: "2026-02", value: 400_000_000, source: "Lovable $400M ARR Feb 2026 (Bloomberg)" },
+        { period: "2026-06", value: 500_000_000, source: "Lovable $500M annualized Jun 2026 (TechCrunch)" },
+      ],
+      users: [
+        { period: "2025-09", value: 140_000, source: "Lovable 140K users (uuid-mappings: lovable-achieves-5-56m-arr)" },
+        { period: "2026-06", value: 8_000_000, source: "Lovable ~8M users 2026 (getpanto)" },
+      ],
+      employees: [{ period: "2026-03", value: 146, source: "Lovable 146 employees (TechCrunch)" }],
+    },
+  },
+  "replit-agent": {
+    anchors: {
+      monthly_arr: [
+        { period: "2025-12", value: 300_000_000, source: "Replit $300M ARR end-2025 (Sacra)" },
+        { period: "2026-04", value: 525_000_000, source: "Replit $525M annualized Apr 2026 (Forbes/Sacra)" },
+      ],
+      valuation: [
+        { period: "2025-09", value: 3_000_000_000, source: "Replit $3B valuation Sep 2025 (Prysm round)" },
+        { period: "2026-03", value: 9_000_000_000, source: "Replit $9B valuation Mar 2026 (TechCrunch)" },
+      ],
+      users: [
+        { period: "2025-09", value: 40_000_000, source: "Replit 40M+ users Sep 2025 (Sacra)" },
+        { period: "2026-03", value: 50_000_000, source: "Replit 50M+ users Mar 2026 (Sacra)" },
+      ],
+    },
+  },
+  "bolt-new": {
+    github: "stackblitz/bolt.new",
+    anchors: {
+      monthly_arr: [{ period: "2025-08", value: 40_000_000, source: "Bolt.new $40M ARR (uuid-mappings: bolt-new-hits-40m-arr)" }],
+    },
+  },
+  "google-jules": {
+    anchors: {
+      swe_bench_verified: [{ period: "2025-06", value: 52.2, source: "Google Jules 52.2% SWE-bench (uuid-mappings: google-jules-public-beta)" }],
+    },
+  },
+  aider: { github: "Aider-AI/aider", pypi: "aider-chat" },
+  cline: { github: "cline/cline", vscode: "saoudrizwan.claude-dev" },
+  continue: { github: "continuedev/continue", vscode: "Continue.continue" },
+  zed: { github: "zed-industries/zed" },
+  "openai-codex-cli": { npm: "@openai/codex", github: "openai/codex" },
+  "snyk-code": { npm: "snyk", github: "snyk/cli" },
+  openhands: { github: "All-Hands-AI/OpenHands", pypi: "openhands-ai" },
+};
+
+// ---------------------------------------------------------------------------
+// Network (best-effort, graceful degradation)
+// ---------------------------------------------------------------------------
+
+async function fetchJson(url: string, retries = 2): Promise<unknown | null> {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(url, { headers: { "User-Agent": "ai-power-rankings-historical-backfill" } });
+      if (res.status === 429) {
+        await sleep(1500 * (attempt + 1));
+        continue;
+      }
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      await sleep(500 * (attempt + 1));
+    }
+  }
+  return null;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function fetchNpmDaily(pkg: string): Promise<DailyDownload[] | null> {
+  const url = `https://api.npmjs.org/downloads/range/${NPM_RANGE_START}:${NPM_RANGE_END}/${pkg}`;
+  const json = (await fetchJson(url)) as { downloads?: DailyDownload[]; error?: string } | null;
+  if (!json || json.error || !Array.isArray(json.downloads)) return null;
+  return json.downloads;
+}
+
+async function fetchGithub(repo: string): Promise<{ stars: number; created: string } | null> {
+  const json = (await fetchJson(`https://api.github.com/repos/${repo}`)) as
+    | { stargazers_count?: number; created_at?: string }
+    | null;
+  if (!json || typeof json.stargazers_count !== "number" || !json.created_at) return null;
+  return { stars: json.stargazers_count, created: json.created_at };
+}
+
+/** Best-effort PyPI daily downloads via pypistats overall (rolling window). */
+async function fetchPypiDaily(pkg: string): Promise<DailyDownload[] | null> {
+  const json = (await fetchJson(`https://pypistats.org/api/packages/${pkg}/overall?mirrors=false`)) as
+    | { data?: Array<{ date?: string; downloads?: number }> }
+    | null;
+  if (!json || !Array.isArray(json.data)) return null;
+  return json.data
+    .filter((d) => typeof d.date === "string")
+    .map((d) => ({ day: d.date as string, downloads: Number(d.downloads) || 0 }));
+}
+
+// ---------------------------------------------------------------------------
+// Anchor interpolation -> Leaf
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve a dated-anchor metric for one period into a provenance leaf.
+ * - strictly between two anchors -> interpolated
+ * - clamped outside the anchor range (or single anchor) -> held_flat
+ */
+function anchorLeaf(anchors: Anchor[], period: string, metricLabel: string): Leaf {
+  const sorted = [...anchors].sort((a, b) => periodToTime(a.period) - periodToTime(b.period));
+  const t = periodToTime(period);
+  const first = sorted[0]!;
+  const last = sorted[sorted.length - 1]!;
+
+  // Single anchor, or outside the anchor window -> hold flat at the nearest end.
+  if (sorted.length === 1 || t <= periodToTime(first.period)) {
+    return {
+      value: first.value,
+      fidelity: "held_flat",
+      source: first.source,
+      as_of: first.period,
+      recovery_note: `No time-series API for ${metricLabel}; held flat at the nearest dated anchor (${first.period}). Not a real ${period} reading.`,
+    };
+  }
+  if (t >= periodToTime(last.period)) {
+    return {
+      value: last.value,
+      fidelity: "held_flat",
+      source: last.source,
+      as_of: last.period,
+      recovery_note: `No time-series API for ${metricLabel}; held flat at the nearest dated anchor (${last.period}). Not a real ${period} reading.`,
+    };
+  }
+
+  // Between two anchors -> linear interpolation.
+  let lo = first;
+  let hi = last;
+  for (let i = 0; i < sorted.length - 1; i++) {
+    if (t >= periodToTime(sorted[i]!.period) && t <= periodToTime(sorted[i + 1]!.period)) {
+      lo = sorted[i]!;
+      hi = sorted[i + 1]!;
+      break;
+    }
+  }
+  const value = interpolateMonthly(lo.value, lo.period, hi.value, hi.period, period);
+  return {
+    value,
+    fidelity: "interpolated",
+    source: `Linear interpolation between dated anchors ${lo.period} (${lo.source}) and ${hi.period} (${hi.source})`,
+    as_of: `estimated for ${period}`,
+    recovery_note: `${metricLabel} has no monthly-history API; value linearly interpolated between two dated news anchors. Flagged interpolated so it can be down-weighted if stricter provenance is required.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Roster
+// ---------------------------------------------------------------------------
+
+interface RosterEntry {
+  tool_id: string;
+  name: string;
+  slug: string;
+}
+
+function loadRoster(): RosterEntry[] {
+  const raw = JSON.parse(readFileSync(ROSTER_PATH, "utf8")) as {
+    rankings: Array<{ tool_id: string; tool_name: string }>;
+  };
+  return raw.rankings.map((r) => ({
+    tool_id: String(r.tool_id),
+    name: r.tool_name,
+    slug: slugify(r.tool_name),
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+interface FetchCaches {
+  npm: Map<string, DailyDownload[] | null>;
+  github: Map<string, { stars: number; created: string } | null>;
+  pypi: Map<string, DailyDownload[] | null>;
+}
+
+function setLeaf(metrics: Record<string, unknown>, path: string[], leaf: Leaf): void {
+  let node = metrics;
+  for (let i = 0; i < path.length - 1; i++) {
+    node[path[i]!] = (node[path[i]!] as Record<string, unknown>) ?? {};
+    node = node[path[i]!] as Record<string, unknown>;
+  }
+  node[path[path.length - 1]!] = leaf;
+}
+
+type FidelityCounts = Record<string, Record<Fidelity, number>>;
+
+function bump(counts: FidelityCounts, metric: string, fidelity: Fidelity): void {
+  counts[metric] ??= { real: 0, interpolated: 0, held_flat: 0, not_applicable: 0 };
+  counts[metric]![fidelity]++;
+}
+
+async function buildCaches(): Promise<FetchCaches> {
+  const npm = new Map<string, DailyDownload[] | null>();
+  const github = new Map<string, { stars: number; created: string } | null>();
+  const pypi = new Map<string, DailyDownload[] | null>();
+
+  const npmPkgs = new Set<string>();
+  const ghRepos = new Set<string>();
+  const pypiPkgs = new Set<string>();
+  for (const s of Object.values(SOURCES)) {
+    if (s.npm) npmPkgs.add(s.npm);
+    if (s.github) ghRepos.add(s.github);
+    if (s.pypi) pypiPkgs.add(s.pypi);
+  }
+
+  for (const pkg of npmPkgs) {
+    process.stdout.write(`  npm   ${pkg} … `);
+    const d = await fetchNpmDaily(pkg);
+    npm.set(pkg, d);
+    console.log(d ? `${d.length} days` : "UNAVAILABLE");
+  }
+  for (const repo of ghRepos) {
+    process.stdout.write(`  gh    ${repo} … `);
+    const d = await fetchGithub(repo);
+    github.set(repo, d);
+    console.log(d ? `${d.stars} stars (since ${d.created.slice(0, 7)})` : "UNAVAILABLE");
+  }
+  for (const pkg of pypiPkgs) {
+    process.stdout.write(`  pypi  ${pkg} … `);
+    const d = await fetchPypiDaily(pkg);
+    pypi.set(pkg, d);
+    console.log(d ? `${d.length} days` : "UNAVAILABLE (rolling window / rate-limited)");
+  }
+
+  return { npm, github, pypi };
+}
+
+function buildToolMetrics(
+  src: ToolSource,
+  period: string,
+  caches: FetchCaches,
+  counts: FidelityCounts
+): Record<string, unknown> {
+  const metrics: Record<string, unknown> = {};
+
+  // npm downloads (REAL)
+  if (src.npm) {
+    const daily = caches.npm.get(src.npm);
+    if (daily) {
+      const value = sumMonthlyDownloads(daily, period);
+      setLeaf(metrics, ["npm", "downloads_last_month"], {
+        value,
+        fidelity: "real",
+        source: `https://api.npmjs.org/downloads/range/${NPM_RANGE_START}:${NPM_RANGE_END}/${src.npm}`,
+        as_of: period,
+        recovery_note: `Sum of daily npm downloads for calendar month ${period}, retrieved live from the npm range API for ${src.npm}.`,
+      });
+      bump(counts, "npm.downloads_last_month", "real");
+    }
+  }
+
+  // PyPI downloads (REAL where the rolling window still covers the month)
+  if (src.pypi) {
+    const daily = caches.pypi.get(src.pypi);
+    const value = daily ? sumMonthlyDownloads(daily, period) : 0;
+    if (daily && value > 0) {
+      setLeaf(metrics, ["pypi", "downloads_last_month"], {
+        value,
+        fidelity: "real",
+        source: `https://pypistats.org/api/packages/${src.pypi}/overall`,
+        as_of: period,
+        recovery_note: `Sum of daily PyPI downloads for ${period} from the pypistats overall series (mirrors excluded).`,
+      });
+      bump(counts, "pypi.downloads_last_month", "real");
+    } else {
+      setLeaf(metrics, ["pypi", "downloads_last_month"], {
+        value: null,
+        fidelity: "not_applicable",
+        source: `https://pypistats.org/api/packages/${src.pypi}/overall`,
+        as_of: null,
+        recovery_note: `PyPI stats retain only a rolling ~180-day window; ${period} has rolled off (or the source was rate-limited). Poll monthly going forward rather than back-filling old months.`,
+      });
+      bump(counts, "pypi.downloads_last_month", "not_applicable");
+    }
+  }
+
+  // GitHub stars (INTERPOLATED: creation -> current)
+  if (src.github) {
+    const gh = caches.github.get(src.github);
+    if (gh) {
+      const createdPeriod = gh.created.slice(0, 7);
+      const value = interpolateMonthly(0, createdPeriod, gh.stars, CURRENT_PERIOD, period);
+      setLeaf(metrics, ["github", "stars"], {
+        value,
+        fidelity: "interpolated",
+        source: `https://api.github.com/repos/${src.github} (current stargazers_count=${gh.stars}) linearly interpolated from repo creation ${createdPeriod} (0 stars) to ${CURRENT_PERIOD}`,
+        as_of: `estimated for ${period}`,
+        recovery_note: `GitHub's REST API returns only the current total; monthly history requires paginating stargazer timestamps or star-history.com. This is a documented linear-interpolation estimate.`,
+      });
+      bump(counts, "github.stars", "interpolated");
+    }
+  }
+
+  // VS Code installs (documented gap -> held_flat null)
+  if (src.vscode) {
+    setLeaf(metrics, ["vscode", "installs"], {
+      value: null,
+      fidelity: "held_flat",
+      source: `https://marketplace.visualstudio.com/items?itemName=${src.vscode}`,
+      as_of: null,
+      recovery_note: `The VS Code Marketplace exposes only a single current cumulative install counter with no dated history. Left null rather than mislabeling today's total as a ${period} reading.`,
+    });
+    bump(counts, "vscode.installs", "held_flat");
+  }
+
+  // Business anchors (interpolated / held_flat)
+  const anchorMetrics: Array<[keyof NonNullable<ToolSource["anchors"]>, string[], string]> = [
+    ["users", ["users"], "user count"],
+    ["monthly_arr", ["monthly_arr"], "ARR"],
+    ["valuation", ["valuation"], "valuation"],
+    ["funding", ["funding"], "funding"],
+    ["employees", ["employees"], "employee count"],
+    ["swe_bench_verified", ["swe_bench", "verified"], "SWE-bench Verified"],
+  ];
+  for (const [key, path, label] of anchorMetrics) {
+    const anchors = src.anchors?.[key];
+    if (!anchors || anchors.length === 0) continue;
+    const leaf = anchorLeaf(anchors, period, label);
+    setLeaf(metrics, path, leaf);
+    bump(counts, path.join("."), leaf.fidelity);
+  }
+
+  return metrics;
+}
+
+function overallConfidence(metrics: Record<string, unknown>): string {
+  const fidelities: Fidelity[] = [];
+  const walk = (node: unknown) => {
+    if (node && typeof node === "object") {
+      if ("fidelity" in (node as Record<string, unknown>)) {
+        fidelities.push((node as Leaf).fidelity);
+      } else {
+        Object.values(node as Record<string, unknown>).forEach(walk);
+      }
+    }
+  };
+  walk(metrics);
+  if (fidelities.length === 0) return "none";
+  const real = fidelities.filter((f) => f === "real").length;
+  if (real > 0 && real >= fidelities.length / 2) return "medium-high";
+  if (real > 0) return "medium";
+  if (fidelities.some((f) => f === "interpolated")) return "low-medium";
+  return "low";
+}
+
+async function main() {
+  const only = process.argv.find((a) => a.startsWith("--only="))?.slice("--only=".length);
+  const periods = only ? PERIODS.filter((p) => p === only) : PERIODS;
+  if (only && periods.length === 0) {
+    console.error(`--only=${only} is not one of ${PERIODS.join(", ")}`);
+    process.exit(1);
+  }
+
+  const roster = loadRoster();
+  console.log(`\n📚 Roster: ${roster.length} tools (from ${ROSTER_PATH.replace(ROOT + "/", "")})`);
+  console.log(`🗓  Periods: ${periods.join(", ")}\n`);
+  console.log("🌐 Fetching external time-series (npm / GitHub / PyPI)…");
+  const caches = await buildCaches();
+
+  if (!existsSync(OUT_DIR)) mkdirSync(OUT_DIR, { recursive: true });
+
+  const generatedAt = new Date().toISOString();
+  const grandCounts: FidelityCounts = {};
+
+  for (const period of periods) {
+    const counts: FidelityCounts = {};
+    const tools: Record<string, unknown> = {};
+
+    for (const entry of roster) {
+      const src = SOURCES[entry.slug];
+      const metrics = src ? buildToolMetrics(src, period, caches, counts) : {};
+      if (Object.keys(metrics).length === 0) {
+        // No substantiated data for this tool this month: emit an empty metrics
+        // block so the file documents the full roster, but the loader will merge
+        // nothing (production keeps the live tools.data value).
+        tools[entry.slug] = {
+          display_name: entry.name,
+          metrics: {},
+          provenance: {
+            overall_confidence: "none",
+            notes: "No external time-series or dated anchor available for this tool/month; live tools.data value is retained in production.",
+          },
+        };
+        continue;
+      }
+      tools[entry.slug] = {
+        display_name: entry.name,
+        metrics,
+        provenance: {
+          overall_confidence: overallConfidence(metrics),
+          notes: "Reconstructed metrics; see per-leaf fidelity/source/recovery_note.",
+        },
+      };
+    }
+
+    const file = {
+      $schema: "historical-metrics-override/v1",
+      period,
+      reconstructed: true,
+      generated_at: generatedAt,
+      methodology_version: "1.0",
+      notes:
+        "Research-augmented historical backfill for the v7.6 ranking engine. Every leaf carries fidelity/source/as_of provenance; the loader (applyHistoricalMetricsOverride) extracts `.value` into tools.data.metrics.* and threads provenance into the persisted ranking row. reconstructed=true flags this as a synthetic period.",
+      fidelity_levels: {
+        real: "Directly retrieved from an external time-series API for this exact calendar month.",
+        interpolated: "Linear interpolation between two real dated anchor points (news/launch events + current snapshot).",
+        held_flat: "No time-series source exists; the last known real value is carried forward, explicitly flagged. Never a real monthly reading.",
+        not_applicable: "No value exists or is recoverable for this tool/metric/month.",
+      },
+      tools,
+    };
+
+    const outPath = join(OUT_DIR, `${period}.json`);
+    writeFileSync(outPath, JSON.stringify(file, null, 2) + "\n");
+
+    // Roll counts into the grand total and print a per-file summary.
+    const summary = Object.entries(counts)
+      .map(([m, c]) => `${m}[real:${c.real} interp:${c.interpolated} flat:${c.held_flat} n/a:${c.not_applicable}]`)
+      .join("  ");
+    console.log(`✅ ${outPath.replace(ROOT + "/", "")}  —  ${summary || "no substantiated metrics"}`);
+    for (const [m, c] of Object.entries(counts)) {
+      grandCounts[m] ??= { real: 0, interpolated: 0, held_flat: 0, not_applicable: 0 };
+      (Object.keys(c) as Fidelity[]).forEach((f) => (grandCounts[m]![f] += c[f]));
+    }
+  }
+
+  console.log("\n📊 Per-metric fidelity totals (all periods):");
+  for (const [m, c] of Object.entries(grandCounts)) {
+    console.log(`   ${m.padEnd(26)} real:${c.real}  interpolated:${c.interpolated}  held_flat:${c.held_flat}  not_applicable:${c.not_applicable}`);
+  }
+  console.log(`\n✨ Wrote ${periods.length} override file(s) to ${OUT_DIR.replace(ROOT + "/", "")}\n`);
+}
+
+main().catch((err) => {
+  console.error("\n💥 generate-historical-metrics failed:", err);
+  process.exit(1);
+});

--- a/scripts/generate-v76-rankings.ts
+++ b/scripts/generate-v76-rankings.ts
@@ -12,14 +12,52 @@
  * (the service intentionally leaves the pooled connection open for the serverless
  * cron path).
  *
+ * Historical backfill flags (additive; the live cron path is unaffected):
+ *   --metrics-source=<path>  Score a period-specific `data/historical-metrics/
+ *                            <period>.json` override instead of only live
+ *                            tools.data. Defaults to
+ *                            `data/historical-metrics/<period>.json` when that
+ *                            file exists; omit/absent -> live tools.data.
+ *   --dry-run                Compute + print the rankings WITHOUT any database
+ *                            access or persistence. Uses an in-memory roster
+ *                            (data/extracted-rankings/2025-09.json) so it runs
+ *                            locally with no NODE_ENV / Neon requirement. Useful
+ *                            for previewing a backfilled month before the gated
+ *                            prod run.
+ *
  * v7.6 combines:
  * 1. npm data quality fix (removed 15 incorrect mappings, 22.9M bogus downloads)
  * 2. Market-validated weights (40% adoption focus)
  * 3. Missing data penalty (confidence multiplier 0.7-1.0 based on completeness)
  *
- * NODE_ENV requirement: `regenerateRankings()` persists the snapshot inside a
- * transaction, which needs the pooled Neon driver. See the fail-fast guard below.
+ * NODE_ENV requirement (non-dry-run only): `regenerateRankings()` persists the
+ * snapshot inside a transaction, which needs the pooled Neon driver. See the
+ * fail-fast guard below.
  */
+
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function parsePeriodArg(): string | undefined {
+  const arg = process.argv.find((a) => a.startsWith("--period="));
+  return arg ? arg.slice("--period=".length) : undefined;
+}
+
+function parseMetricsSourceArg(period: string | undefined): string | undefined {
+  const arg = process.argv.find((a) => a.startsWith("--metrics-source="));
+  if (arg) return arg.slice("--metrics-source=".length);
+  // Default: auto-pick data/historical-metrics/<period>.json when it exists.
+  if (period) {
+    const def = join(ROOT, "data", "historical-metrics", `${period}.json`);
+    if (existsSync(def)) return def;
+  }
+  return undefined;
+}
+
+const DRY_RUN = process.argv.includes("--dry-run");
 
 // ---------------------------------------------------------------------------
 // Fail-fast environment guard — MUST run before any DB module is loaded.
@@ -31,14 +69,15 @@
 // Why the guard exists: regenerateRankings() -> saveSnapshot() persists the
 // ranking snapshot inside a transaction, and lib/db/connection only selects the
 // transaction-capable pooled Neon driver when NODE_ENV is "production" or
-// "staging". A plain local run (`npx tsx scripts/generate-v76-rankings.ts`)
-// picks the default neon-http driver and fails deep in execution with the
-// cryptic "Error: No transactions support in neon-http driver". Fail fast here
-// with an actionable message instead. This does NOT affect the Vercel monthly
-// cron, which runs the API route with NODE_ENV=production.
+// "staging". A plain local run picks the default neon-http driver and fails deep
+// in execution with "No transactions support in neon-http driver". Fail fast
+// here instead.
+//
+// --dry-run performs NO database access (in-memory roster, no saveSnapshot), so
+// it deliberately bypasses this guard and runs anywhere.
 // ---------------------------------------------------------------------------
 const NODE_ENV = process.env.NODE_ENV;
-if (NODE_ENV !== "production" && NODE_ENV !== "staging") {
+if (!DRY_RUN && NODE_ENV !== "production" && NODE_ENV !== "staging") {
   console.error(
     `\n❌ Refusing to run: NODE_ENV is "${NODE_ENV ?? "unset"}" (expected "production" or "staging").\n\n` +
       "This script writes a ranking snapshot in a transaction, which requires the\n" +
@@ -47,14 +86,47 @@ if (NODE_ENV !== "production" && NODE_ENV !== "staging") {
       '  "Error: No transactions support in neon-http driver"\n\n' +
       "Re-run via the repo convention:\n" +
       "  ./scripts/run-with-prod-env.sh npx tsx scripts/generate-v76-rankings.ts\n\n" +
-      "(or set NODE_ENV=production with a valid DATABASE_URL).\n"
+      "(or set NODE_ENV=production with a valid DATABASE_URL).\n\n" +
+      "To PREVIEW without any DB access, add --dry-run.\n"
   );
   process.exit(1);
 }
 
-function parsePeriodArg(): string | undefined {
-  const arg = process.argv.find((a) => a.startsWith("--period="));
-  return arg ? arg.slice("--period=".length) : undefined;
+/**
+ * In-memory persistence for --dry-run: loads the 31-tool roster from the last
+ * real export and scores it with EMPTY base metrics so the historical override
+ * fully drives the result. saveSnapshot is a no-op (nothing is persisted).
+ *
+ * NOTE: this is an APPROXIMATION of production, whose base is the live
+ * tools.data. It exists to prove the override path yields genuine month-over-
+ * month movement (not a flat copy), not to reproduce exact prod scores.
+ */
+async function buildDryRunPersistence() {
+  const { readFileSync } = await import("node:fs");
+  const { slugify } = await import("@/lib/historical-metrics/slugify");
+  const rosterPath = join(ROOT, "data", "extracted-rankings", "2025-09.json");
+  const raw = JSON.parse(readFileSync(rosterPath, "utf8")) as {
+    rankings: Array<{ tool_id: string; tool_name: string }>;
+  };
+  const sourceTools = raw.rankings.map((r) => ({
+    id: String(r.tool_id),
+    name: r.tool_name,
+    slug: slugify(r.tool_name),
+    category: "code-editor",
+    status: "active",
+    data: { metrics: {} } as Record<string, unknown>,
+  }));
+
+  return {
+    persistence: {
+      loadActiveTools: async () => sourceTools,
+      loadCurrentRankings: async () => null,
+      saveSnapshot: async () => {
+        /* dry-run: intentionally no-op */
+      },
+    },
+    rosterCount: sourceTools.length,
+  };
 }
 
 async function main() {
@@ -64,9 +136,14 @@ async function main() {
   const { regenerateRankings } = await import("@/lib/services/ranking-generation.service");
 
   const period = parsePeriodArg();
+  const metricsOverridePath = parseMetricsSourceArg(period);
 
   console.log("\n🚀 Generating Rankings with Algorithm v7.6 (Market-Validated + npm Fix)\n");
   console.log("=".repeat(80));
+  if (DRY_RUN) console.log("🧪 DRY-RUN: no database access, nothing will be persisted.");
+  if (metricsOverridePath) {
+    console.log(`📥 Historical override: ${metricsOverridePath.replace(ROOT + "/", "")}`);
+  }
   console.log("\n📊 Algorithm v7.6 Weights (Market-Validated):");
   console.log(`   Agentic Capability:    ${ALGORITHM_V76_WEIGHTS.agenticCapability.toFixed(3)}`);
   console.log(`   Innovation:            ${ALGORITHM_V76_WEIGHTS.innovation.toFixed(3)}`);
@@ -77,8 +154,44 @@ async function main() {
   console.log(`   Development Velocity:  ${ALGORITHM_V76_WEIGHTS.developmentVelocity.toFixed(3)}`);
   console.log(`   Platform Resilience:   ${ALGORITHM_V76_WEIGHTS.platformResilience.toFixed(3)}`);
 
+  if (DRY_RUN) {
+    const { persistence, rosterCount } = await buildDryRunPersistence();
+    // Anchor the clock to the target month for deterministic maturity scoring.
+    const now = period ? () => new Date(`${period}-01T00:00:00Z`) : undefined;
+    console.log(`\n🧮 Scoring ${rosterCount} roster tools (dry-run, no persistence)…`);
+
+    // Score through the in-memory persistence and capture the snapshot the
+    // service *would* have saved (saveSnapshot never touches a database here).
+    let captured: Array<{ rank: number; tool_name: string; score: number; tier: string; reconstructed?: boolean }> = [];
+    const capturing = {
+      ...persistence,
+      saveSnapshot: async (input: { data: typeof captured }) => {
+        captured = input.data;
+      },
+    };
+    await regenerateRankings({
+      ...(period ? { period } : {}),
+      ...(metricsOverridePath ? { metricsOverridePath } : {}),
+      persistence: capturing as never,
+      ...(now ? { now } : {}),
+    });
+
+    console.log("\n" + "=".repeat(80));
+    console.log(`🏁 DRY-RUN Top 15 — period ${period ?? "(current)"}`);
+    console.log("=".repeat(80));
+    for (const r of captured.slice(0, 15)) {
+      const flag = r.reconstructed ? " *reconstructed" : "";
+      console.log(`   #${String(r.rank).padStart(2)}  ${r.tool_name.padEnd(28)} ${r.score.toFixed(3)}  [${r.tier}]${flag}`);
+    }
+    console.log("\n🧪 Dry-run complete. Nothing was written to the database.\n");
+    return;
+  }
+
   console.log("\n🧮 Scoring active tools and persisting snapshot...");
-  const result = await regenerateRankings(period ? { period } : {});
+  const result = await regenerateRankings({
+    ...(period ? { period } : {}),
+    ...(metricsOverridePath ? { metricsOverridePath } : {}),
+  });
 
   console.log("\n" + "=".repeat(80));
   console.log("✅ Rankings Generated Successfully (v7.6)!");
@@ -105,14 +218,18 @@ async function main() {
 
 main()
   .then(async () => {
-    const { closeDb } = await import("@/lib/db/connection");
-    await closeDb();
+    if (!DRY_RUN) {
+      const { closeDb } = await import("@/lib/db/connection");
+      await closeDb();
+    }
     console.log("\n✨ Done! Rankings are now live with Algorithm v7.6.\n");
     process.exit(0);
   })
   .catch(async (error) => {
     console.error("\n💥 Fatal Error:", error);
-    const { closeDb } = await import("@/lib/db/connection");
-    await closeDb();
+    if (!DRY_RUN) {
+      const { closeDb } = await import("@/lib/db/connection");
+      await closeDb();
+    }
     process.exit(1);
   });


### PR DESCRIPTION
## Summary
- Root cause: Historical AI Tool Rankings chart flat-lined Nov 2025→Jul 2026 due to ~8 months without snapshots; eventual regeneration scored stale tools.data
- Solution: Research-augmented override system using real data sources (npm/PyPI APIs, GitHub stars, dated news anchors)
- Reconstructed data is fidelity-flagged (npm/PyPI real, stars/ARR interpolated, some fields held-flat) with `reconstructed: true` provenance
- Live cron ranking path unchanged; this adds optional `metricsOverridePath` for backfill only
- Dry-run verified genuine movement in metrics; tests pass (159 passed, 0 failed)
- Prod publish is a separate gated step

## Implementation
- `regenerateRankings()` reads `data/historical-metrics/<period>.json` via new `metricsOverridePath` option (existsSync-guarded)
- `applyHistoricalMetricsOverride()` deep-merges override `.value` leaves
- `scripts/generate-v76-rankings.ts`: added `--metrics-source` and `--dry-run` flags
- `scripts/generate-historical-metrics.ts`: re-runnable override generator
- 7 monthly override files (31 tools each) + unit tests for metrics application

## Test plan
- [x] Unit tests pass (159 passed, 0 failed)
- [x] Dry-run shows expected metric movement
- [x] Historical override files load correctly
- [x] Live cron path unaffected by changes
- [x] Reconstructed periods properly flagged

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools