### PR TITLE
feat(rankings): Terminal-Bench agentic signal + v7.9 recalibration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ wheels/
 .env*.local
 kuzu-memories/
 .trusty-search/
+.trusty-mpm/sessions/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- feat(rankings): v7.9 — blend Terminal-Bench (terminal-bench 2.1) into the agentic-capability factor as a second benchmark alongside SWE-bench (best scaffold+model row per tool via a hand-curated allowlist, tunable `TB_BLEND_WEIGHT` default 0.4, no factor-weight change); wired matched `terminal_bench` leaves into `data/historical-metrics/2026-06.json` with full provenance and a curated source capture at `data/historical-metrics/sources/terminal-bench-2.1.json`
+
+### Changed
+- feat(rankings): v7.9 calibration so Terminal-Bench differentiates already-saturated leaders — SWE-bench Verified anchor 70 → 88 (`SWE_BENCH_ANCHOR`, de-saturates today's top scores to the low-90s) and agentic heuristic bonuses now fill remaining headroom instead of adding-then-clipping at 100 (`AGENTIC_BONUS_HEADROOM_SCALE`). Reshapes the SWE-bench contribution for all 31 tools (surfaced in the impact analysis); factor weights unchanged
+
 ## [0.5.0] - 2026-07-16
 
 ### Changed

--- a/config/algorithm-config.json
+++ b/config/algorithm-config.json
@@ -1,7 +1,7 @@
 {
-  "version": "7.6",
+  "version": "7.9",
   "name": "Market-Validated Scoring",
-  "releaseDate": "2025-11-01",
+  "releaseDate": "2026-07-18",
   "description": "Market-validated scoring that combines real-world adoption metrics with technical capabilities for objective evaluations",
   "fullDescription": "Our ranking system combines real-world adoption metrics with technical capabilities to provide objective evaluations of AI coding tools. We prioritize measurable data over theoretical assessments.",
 
@@ -25,7 +25,7 @@
       "name": "Agentic Capability",
       "weight": 12,
       "description": "Autonomous coding abilities",
-      "details": "Task planning sophistication, Multi-step problem solving, Self-correction abilities, Tool/API integration, Autonomous iteration"
+      "details": "Task planning sophistication, Multi-step problem solving, Self-correction abilities, Tool/API integration, Autonomous iteration, SWE-bench Verified + Terminal-Bench (terminal-bench 2.1) benchmark blend"
     },
     {
       "id": "market_traction",
@@ -110,6 +110,20 @@
   },
 
   "changelog": {
+    "v7.9": {
+      "date": "2026-07-18",
+      "focus": "Terminal-Bench benchmark signal",
+      "changes": [
+        "Blended Terminal-Bench (terminal-bench 2.1) into Agentic Capability as a second benchmark alongside SWE-bench Verified",
+        "Default blend 0.6 SWE-bench / 0.4 Terminal-Bench (tunable via TB_BLEND_WEIGHT); whichever benchmark exists when only one is present",
+        "Terminal-Bench normalized linearly against an 85% ceiling anchor (headroom above today's 83.8% #1)",
+        "Retuned the SWE-bench Verified anchor 70 → 88 (SWE_BENCH_ANCHOR) so today's leaders no longer saturate at 100 — a prerequisite for the blend to differentiate them; affects the SWE-bench contribution for ALL tools",
+        "Agentic heuristic bonuses (category/multi-file/subprocess/keyword) now FILL remaining headroom instead of adding-then-clipping at 100 (AGENTIC_BONUS_HEADROOM_SCALE=60), so a strong benchmark blend is never re-capped away",
+        "Attribution is a hand-curated scaffold→tool allowlist (Claude Code, OpenAI Codex CLI); no fuzzy matching",
+        "Factor weights unchanged from v7.6",
+        "Aligned config version with the engine ALGORITHM_VERSION (was stale at 7.6 through v7.7/v7.8)"
+      ]
+    },
     "v7.6": {
       "date": "2025-11-01",
       "focus": "Market-Validated Scoring",

--- a/data/historical-metrics/2026-06.json
+++ b/data/historical-metrics/2026-06.json
@@ -52,6 +52,13 @@
             "as_of": "2025-11-24",
             "recovery_note": "Claude Opus 4.5"
           }
+        },
+        "terminal_bench": {
+          "value": 83.8,
+          "fidelity": "real",
+          "source": "https://www.tbench.ai/leaderboard/terminal-bench/2.1",
+          "as_of": "2026-06-07",
+          "recovery_note": "Terminal-Bench 2.1 best row for the Claude Code scaffold: Fable 5 (xhigh), 83.8% (leaderboard #1 overall). See data/historical-metrics/sources/terminal-bench-2.1.json."
         }
       },
       "provenance": {
@@ -567,6 +574,13 @@
             "as_of": "2025-08-07",
             "recovery_note": "GPT-5"
           }
+        },
+        "terminal_bench": {
+          "value": 83.1,
+          "fidelity": "real",
+          "source": "https://www.tbench.ai/leaderboard/terminal-bench/2.1",
+          "as_of": "2026-05-01",
+          "recovery_note": "Terminal-Bench 2.1 best row for the Codex scaffold: GPT-5.5 (xhigh), 83.1% (leaderboard #2 overall); Codex scaffold maps to OpenAI Codex CLI. See data/historical-metrics/sources/terminal-bench-2.1.json."
         }
       },
       "provenance": {

--- a/data/historical-metrics/sources/terminal-bench-2.1.json
+++ b/data/historical-metrics/sources/terminal-bench-2.1.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "terminal-bench-source/v1",
+  "benchmark": "Terminal-Bench",
+  "version": "terminal-bench 2.1",
+  "source": "https://www.tbench.ai/leaderboard/terminal-bench/2.1",
+  "captured_at": "2026-07-18",
+  "captured_by": "manual WebFetch of the live leaderboard, cross-checked against the research pass",
+  "notes": "Terminal-Bench reports accuracy per SCAFFOLD (agent harness) × MODEL. No JSON/CSV endpoint exists for terminal-bench 2.1 (server-rendered HTML; task suite: github.com/laude-institute/terminal-bench, harness: github.com/harbor-framework/harbor) — this is a curated static capture. Attribution to ranked tools is a hand-curated allowlist (lib/terminal-bench-mapping.ts): only 'Claude Code' → claude-code and 'Codex' → openai-codex-cli earn credit; 'Cursor CLI' and 'Gemini CLI' are excluded as likely-distinct products, and generic harnesses ('Terminus 2', 'mini-SWE-agent') have no ranked counterpart. Each credited tool takes its single BEST (highest-accuracy) row across all models; the winning scaffold+model is recorded in recovery_note.",
+  "leaderboard": [
+    { "rank": 1, "scaffold": "Claude Code", "model": "Fable 5", "accuracy": 83.8, "as_of": "2026-06-07" },
+    { "rank": 2, "scaffold": "Codex", "model": "GPT-5.5", "accuracy": 83.1, "as_of": "2026-05-01" },
+    { "rank": 3, "scaffold": "Terminus 2", "model": "Fable 5", "accuracy": 80.4, "as_of": "2026-06-05" },
+    { "rank": 4, "scaffold": "Cursor CLI", "model": "Grok 4.5", "accuracy": 79.3, "as_of": "2026-07-09" },
+    { "rank": 5, "scaffold": "Claude Code", "model": "Opus 4.8", "accuracy": 78.9, "as_of": "2026-07-09" },
+    { "rank": 6, "scaffold": "Codex", "model": "GPT-5.6 Terra", "accuracy": 78.4, "as_of": "2026-07-11" },
+    { "rank": 7, "scaffold": "Terminus 2", "model": "GPT-5.5", "accuracy": 78.0, "as_of": "2026-05-01" },
+    { "rank": 8, "scaffold": "mini-SWE-agent", "model": "Muse Spark 1.1", "accuracy": 76.2, "as_of": "2026-07-09" },
+    { "rank": 9, "scaffold": "Codex", "model": "GPT-5.6 Luna", "accuracy": 75.7, "as_of": "2026-07-11" },
+    { "rank": 10, "scaffold": "Claude Code", "model": "Sonnet 5", "accuracy": 74.6, "as_of": "2026-07-09" },
+    { "rank": 11, "scaffold": "Terminus 2", "model": "Gemini 3 Pro", "accuracy": 73.9, "as_of": "2026-05-01" },
+    { "rank": 12, "scaffold": "Claude Code", "model": "Opus 4.7", "accuracy": 68.9, "as_of": "2026-05-01" },
+    { "rank": 13, "scaffold": "Terminus 2", "model": "Opus 4.7", "accuracy": 66.1, "as_of": "2026-05-01" },
+    { "rank": 14, "scaffold": "Gemini CLI", "model": "Gemini 3 Pro", "accuracy": 65.8, "as_of": "2026-05-01" },
+    { "rank": 14, "scaffold": "Gemini CLI", "model": "Gemini 3.1 Pro", "accuracy": 65.8, "as_of": "2026-05-05" },
+    { "rank": 16, "scaffold": "Terminus 2", "model": "Gemini 3.1 Pro", "accuracy": 65.6, "as_of": "2026-05-05" },
+    { "rank": 17, "scaffold": "Claude Code", "model": "GLM-5.1", "accuracy": 58.7, "as_of": "2026-05-01" }
+  ],
+  "matched": {
+    "claude-code": {
+      "display_name": "Claude Code",
+      "terminal_bench": {
+        "value": 83.8,
+        "fidelity": "real",
+        "source": "https://www.tbench.ai/leaderboard/terminal-bench/2.1",
+        "as_of": "2026-06-07",
+        "recovery_note": "Terminal-Bench 2.1 best row for the Claude Code scaffold: Fable 5 (xhigh), 83.8% (leaderboard #1 overall)"
+      }
+    },
+    "openai-codex-cli": {
+      "display_name": "OpenAI Codex CLI",
+      "terminal_bench": {
+        "value": 83.1,
+        "fidelity": "real",
+        "source": "https://www.tbench.ai/leaderboard/terminal-bench/2.1",
+        "as_of": "2026-05-01",
+        "recovery_note": "Terminal-Bench 2.1 best row for the Codex scaffold: GPT-5.5 (xhigh), 83.1% (leaderboard #2 overall); Codex scaffold maps to OpenAI Codex CLI"
+      }
+    }
+  },
+  "excluded": {
+    "Cursor CLI": "likely a different product from the ranked 'Cursor' editor — not auto-aliased",
+    "Gemini CLI": "likely a different product from the ranked 'Google Gemini Code Assist' — not auto-aliased",
+    "Terminus 2": "generic benchmark harness — no ranked-tool counterpart",
+    "mini-SWE-agent": "generic benchmark harness — no ranked-tool counterpart"
+  }
+}

--- a/lib/ranking-algorithm-v76.test.ts
+++ b/lib/ranking-algorithm-v76.test.ts
@@ -13,8 +13,11 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  AGENTIC_BONUS_HEADROOM_SCALE,
   ALGORITHM_V76_WEIGHTS,
   RankingEngineV76,
+  SWE_BENCH_ANCHOR,
+  TB_BLEND_WEIGHT,
   type ToolMetricsV76,
 } from "./ranking-algorithm-v76";
 
@@ -74,9 +77,9 @@ describe("RankingEngineV76", () => {
   const engine = new RankingEngineV76(ALGORITHM_V76_WEIGHTS);
 
   describe("getAlgorithmInfo", () => {
-    it("reports the current v7.8 methodology and weights", () => {
+    it("reports the current v7.9 methodology and weights", () => {
       const info = RankingEngineV76.getAlgorithmInfo();
-      expect(info.version).toBe("v7.8");
+      expect(info.version).toBe("v7.9");
       expect(info.weights).toEqual(ALGORITHM_V76_WEIGHTS);
     });
 
@@ -99,7 +102,7 @@ describe("RankingEngineV76", () => {
       const score = engine.calculateToolScore(richTool, FIXED_DATE);
       expect(score.tool_id).toBe("t-rich");
       expect(score.tool_slug).toBe("alpha-copilot");
-      expect(score.algorithm_version).toBe("v7.8");
+      expect(score.algorithm_version).toBe("v7.9");
     });
 
     it("keeps every factor score within the [0,100] range", () => {
@@ -183,6 +186,134 @@ describe("RankingEngineV76", () => {
       expect(highAdoption.factorScores.developerAdoption).toBeGreaterThan(
         lowAdoption.factorScores.developerAdoption
       );
+    });
+  });
+
+  /**
+   * v7.9 blend + calibration retune. These fixtures carry NO category /
+   * description / multi-file signal, so with the default (headroom) bonus model
+   * and zero bonus points the agentic factor equals the benchmark base exactly —
+   * isolating the SWE-bench-anchor and Terminal-Bench math.
+   */
+  describe("calculateAgenticCapability — SWE-bench + Terminal-Bench blend", () => {
+    /** Minimal tool: only the metrics under test drive the agentic factor. */
+    const benchTool = (metrics: Record<string, unknown>): ToolMetricsV76 => ({
+      tool_id: "t-bench",
+      name: "Bench Tool",
+      slug: "bench-tool",
+      status: "active",
+      info: { metrics },
+    });
+
+    const agentic = (metrics: Record<string, unknown>): number =>
+      engine.calculateToolScore(benchTool(metrics), FIXED_DATE).factorScores
+        .agenticCapability;
+
+    // Normalized-contribution helpers against the CURRENT anchors.
+    const swe = (verified: number) => Math.min(100, (verified / SWE_BENCH_ANCHOR) * 100);
+    const tb = (acc: number) => Math.min(100, (acc / 85) * 100);
+
+    it("exports a tunable blend weight defaulting to 0.4", () => {
+      expect(TB_BLEND_WEIGHT).toBe(0.4);
+    });
+
+    it("normalizes SWE-bench against the retuned 88% anchor (leaders unsaturated)", () => {
+      expect(SWE_BENCH_ANCHOR).toBe(88);
+      // Today's best real SWE-bench (80.9%) must NOT saturate — lands low-90s.
+      const leader = agentic({ swe_bench: { verified: 80.9 } });
+      expect(leader).toBeCloseTo((80.9 / 88) * 100, 10);
+      expect(leader).toBeGreaterThan(90);
+      expect(leader).toBeLessThan(95);
+    });
+
+    it("uses SWE-bench alone when only SWE-bench is present", () => {
+      // 49 / 88 * 100 = 55.6818…
+      expect(agentic({ swe_bench: { verified: 49 } })).toBeCloseTo(swe(49), 10);
+    });
+
+    it("uses Terminal-Bench alone when only Terminal-Bench is present", () => {
+      // 68 / 85 * 100 = 80
+      expect(agentic({ terminal_bench: 68 })).toBeCloseTo(80, 10);
+    });
+
+    it("blends the two when both are present (0.6·SWE + 0.4·TB)", () => {
+      const sweOnly = agentic({ swe_bench: { verified: 49 } }); // ~55.68
+      const tbOnly = agentic({ terminal_bench: 68 }); // 80
+      const both = agentic({ swe_bench: { verified: 49 }, terminal_bench: 68 });
+      expect(both).toBeCloseTo((1 - TB_BLEND_WEIGHT) * swe(49) + TB_BLEND_WEIGHT * tb(68), 10);
+      // The blend sits strictly between the two single-signal scores.
+      expect(both).toBeGreaterThan(sweOnly);
+      expect(both).toBeLessThan(tbOnly);
+    });
+
+    it("falls back to the neutral base (50) when neither benchmark is present", () => {
+      expect(agentic({})).toBe(50);
+    });
+
+    it("coerces string-stored Terminal-Bench accuracy", () => {
+      expect(agentic({ terminal_bench: "68" })).toBeCloseTo(80, 10);
+    });
+
+    it("ignores a zero/invalid Terminal-Bench value (treated as absent)", () => {
+      // TB=0 is no-data, so SWE-bench alone drives the score (no blend down).
+      expect(agentic({ swe_bench: { verified: 49 }, terminal_bench: 0 })).toBeCloseTo(
+        swe(49),
+        10
+      );
+    });
+  });
+
+  /**
+   * v7.9 cap interaction. The heuristic bonuses (category etc.) must NOT re-cap
+   * the factor to 100 and erase the benchmark blend. These tests pin the
+   * headroom-fill model and contrast it with the legacy additive model (used
+   * only to reconstruct the impact-analysis baseline).
+   */
+  describe("calculateAgenticCapability — headroom cap keeps the blend visible", () => {
+    /** A tool with a category bonus (code-editor = +15) plus a benchmark. */
+    const toolWith = (verified: number, terminal_bench?: number): ToolMetricsV76 => ({
+      tool_id: "t-cap",
+      name: "Cap Tool",
+      slug: "cap-tool",
+      category: "code-editor",
+      status: "active",
+      info: { metrics: { swe_bench: { verified }, ...(terminal_bench ? { terminal_bench } : {}) } },
+    });
+
+    const headroom = new RankingEngineV76(ALGORITHM_V76_WEIGHTS); // default: headroom
+    const additive = new RankingEngineV76(ALGORITHM_V76_WEIGHTS, {
+      sweBenchAnchor: 88,
+      bonusModel: "additive",
+    });
+    const agentic = (eng: RankingEngineV76, tool: ToolMetricsV76) =>
+      eng.calculateToolScore(tool, FIXED_DATE).factorScores.agenticCapability;
+
+    it("exports the headroom scale", () => {
+      expect(AGENTIC_BONUS_HEADROOM_SCALE).toBe(60);
+    });
+
+    it("legacy additive model re-saturates both leaders to 100 (blend erased)", () => {
+      // base(80.9)=91.9 and base(74.9)=85.1; +15 category → both clip to 100.
+      expect(agentic(additive, toolWith(80.9))).toBeCloseTo(100, 6);
+      expect(agentic(additive, toolWith(74.9))).toBeCloseTo(100, 6);
+    });
+
+    it("headroom model keeps both leaders below 100 and ordered by benchmark", () => {
+      const strong = agentic(headroom, toolWith(80.9));
+      const weaker = agentic(headroom, toolWith(74.9));
+      expect(strong).toBeLessThan(100);
+      expect(weaker).toBeLessThan(100);
+      // A higher SWE-bench base yields a strictly higher factor — not tied at 100.
+      expect(strong).toBeGreaterThan(weaker);
+      // base + (100-base)*15/60 for verified=80.9
+      const base = (80.9 / 88) * 100;
+      expect(strong).toBeCloseTo(base + (100 - base) * (15 / 60), 6);
+    });
+
+    it("Terminal-Bench lifts the final factor even with the category bonus present", () => {
+      const withoutTB = agentic(headroom, toolWith(80.9));
+      const withTB = agentic(headroom, toolWith(80.9, 83.8));
+      expect(withTB).toBeGreaterThan(withoutTB);
     });
   });
 });

--- a/lib/ranking-algorithm-v76.ts
+++ b/lib/ranking-algorithm-v76.ts
@@ -1,7 +1,11 @@
 
 import { hasPositiveNumeric, parseNumericOr, parseNumeric } from "./parse-numeric";
 import { calculateToolNewsImpact, type NewsArticle } from "./ranking-news-impact";
-import { scoreArrContribution, scoreUsersContribution } from "./ranking-metric-curves";
+import {
+  scoreArrContribution,
+  scoreTerminalBenchContribution,
+  scoreUsersContribution,
+} from "./ranking-metric-curves";
 
 /**
  * Single source of truth for the ranking algorithm version.
@@ -14,10 +18,87 @@ import { scoreArrContribution, scoreUsersContribution } from "./ranking-metric-c
  * so every factor reads one canonical value per field instead of silently
  * picking data.info.metrics.* vs data.metrics.* per factor.
  *
+ * Bumped v7.8 → v7.9: Terminal-Bench (terminal-bench 2.1) blended into the
+ * agentic-capability factor as a SECOND benchmark signal alongside SWE-bench
+ * (see calculateAgenticCapability + TB_BLEND_WEIGHT). Calibrated so the blend
+ * actually differentiates leaders: the SWE-bench anchor moved 70 → 88
+ * (SWE_BENCH_ANCHOR) to de-saturate today's top scores, and heuristic bonuses
+ * now fill remaining headroom instead of adding-then-clipping at 100
+ * (AGENTIC_BONUS_HEADROOM_SCALE) so a strong benchmark blend is never re-capped
+ * away. Factor WEIGHTS are unchanged; this only reshapes the agentic base.
+ *
  * NOTE: existing v76 content slugs (e.g. `algorithm-v76-november-2025-rankings`)
  * are historical references and intentionally keep their v7.6 naming.
  */
-export const ALGORITHM_VERSION = "v7.8";
+export const ALGORITHM_VERSION = "v7.9";
+
+/**
+ * Blend weight for Terminal-Bench when BOTH benchmarks are present on a tool.
+ *
+ * Agentic base = (1 - TB_BLEND_WEIGHT) · sweBenchScore
+ *                     + TB_BLEND_WEIGHT · terminalBenchScore
+ *
+ * where each *Score is that benchmark's normalized 0–100 contribution. At the
+ * default 0.4 this is `0.6·SWE + 0.4·Terminal-Bench`. When only one benchmark is
+ * present the tool uses whichever exists (no blend). This is the single knob the
+ * algorithm owner retunes to weight Terminal-Bench more or less heavily; it does
+ * NOT touch ALGORITHM_V76_WEIGHTS (the cross-factor proportions).
+ */
+export const TB_BLEND_WEIGHT = 0.4;
+
+/**
+ * SWE-bench Verified normalization anchor (percent), i.e. the accuracy that maps
+ * to a normalized contribution of 100.
+ *
+ * v7.9 raised this from 70 → 88 (calibration). At 70 every current leader
+ * saturated (Claude Opus 4.5 @ 80.9% → 115 → capped 100), which erased the
+ * SWE↔Terminal-Bench blend: two tools both pinned at 100 cannot be separated by
+ * a ≤100 second benchmark. 88 is chosen so today's best real SWE-bench (80.9%)
+ * lands at 80.9/88 ≈ 91.9 — de-saturated, in the low-90s, with headroom above —
+ * while no tool in the current field (max 80.9%) reaches the anchor. This
+ * changes the SWE-bench contribution for ALL tools, not just Terminal-Bench
+ * matches; that is intended and surfaced in the impact analysis.
+ */
+export const SWE_BENCH_ANCHOR = 88;
+
+/**
+ * Headroom scale for the agentic HEURISTIC bonuses (category / multi-file /
+ * subprocess / capability-keyword).
+ *
+ * v7.9 stopped these bonuses from ADDING raw points and clipping the factor at
+ * 100 — which re-saturated any tool whose benchmark base was already high and so
+ * erased the retuned blend. Instead each unit of bonus now FILLS a fraction of
+ * the remaining headroom between the benchmark base and 100:
+ *
+ *     factor = base + (100 - base) · min(1, bonusPoints / AGENTIC_BONUS_HEADROOM_SCALE)
+ *
+ * Because the fill fraction is < 1 for any realistic bonus stack (the richest
+ * plausible stack is category 20 + multi-file 10 + subprocess ~10 + keyword ~9
+ * ≈ 49 < 60), a higher benchmark base ALWAYS yields a higher final factor —
+ * the SWE+Terminal-Bench blend can never be flattened away by the bonus/cap.
+ * 60 leaves that guaranteed margin; lowering it toward ~49 would risk
+ * re-saturating a maximally-endowed tool. Set to reproduce the legacy additive
+ * behavior only via the `additive` calibration model (used to compute the A
+ * baseline in the impact analysis).
+ */
+export const AGENTIC_BONUS_HEADROOM_SCALE = 60;
+
+/**
+ * Tunable agentic-capability calibration. Defaults reproduce the shipped v7.9
+ * behavior; the impact-analysis script overrides these to reconstruct the v7.8
+ * baseline (anchor 70 + legacy additive-then-clip bonuses) without resurrecting
+ * old code.
+ */
+export interface AgenticCalibration {
+  /** SWE-bench Verified anchor; default {@link SWE_BENCH_ANCHOR} (88). */
+  sweBenchAnchor?: number;
+  /**
+   * How heuristic bonuses combine with the benchmark base:
+   * - `"headroom"` (default, v7.9): fill remaining headroom, never masks the blend.
+   * - `"additive"` (legacy v7.8): add raw points then clip at 100.
+   */
+  bonusModel?: "headroom" | "additive";
+}
 
 export interface RankingWeightsV76 {
   agenticCapability: number;
@@ -91,6 +172,11 @@ export interface ToolMetricsV76 {
         lite?: number | string;
         full?: number | string;
       };
+      // Terminal-Bench accuracy (percent, 0–100) for this tool's BEST scaffold+model
+      // row. Canonical top-level path only (data.metrics.terminal_bench) — NEVER
+      // the nested data.info.metrics copy (v7.8 path-shadowing). May be string-
+      // stored; coerced via parseNumeric at read time.
+      terminal_bench?: number | string;
       news_mentions?: number;
       users?: number | string;
       monthly_arr?: number | string;
@@ -421,7 +507,10 @@ export function canonicalizeMetricPaths(
 }
 
 export class RankingEngineV76 {
-  constructor(private weights: RankingWeightsV76 = ALGORITHM_V76_WEIGHTS) {}
+  constructor(
+    private weights: RankingWeightsV76 = ALGORITHM_V76_WEIGHTS,
+    private calibration: AgenticCalibration = {}
+  ) {}
 
   /**
    * Single normalization step at load: canonicalize the tool's METRICS subtree
@@ -492,21 +581,57 @@ export class RankingEngineV76 {
    * Calculate agentic capability with enhanced differentiation
    */
   private calculateAgenticCapability(metrics: ToolMetricsV76): number {
-    let score = 50; // Base score
+    const sweBenchAnchor = this.calibration.sweBenchAnchor ?? SWE_BENCH_ANCHOR;
 
-    // SWE-bench is the best indicator
-    // SWE-bench values may be stored as strings ("72%", "49.2"); coerce first
-    // so a real benchmark result isn't discarded as non-numeric.
+    // ---- Benchmark base: SWE-bench blended with Terminal-Bench --------------
+    // Two independent benchmark signals feed the agentic base. Each is
+    // normalized to a 0–100 contribution against its anchor; when both exist
+    // they are combined via TB_BLEND_WEIGHT, otherwise the tool uses whichever
+    // it has. The blend operates on the UNSATURATED normalized values (the
+    // v7.9 anchor keeps today's leaders below 100), so Terminal-Bench can
+    // actually separate them. No factor weight changes here.
+
+    // SWE-bench normalized contribution (or null when absent).
+    // Values may be stored as strings ("72%", "49.2"); coerce first so a real
+    // benchmark result isn't discarded as non-numeric.
     const sweBench = metrics.info?.metrics?.swe_bench;
     const verified = parseNumeric(sweBench?.verified);
     const lite = parseNumeric(sweBench?.lite);
     const full = parseNumeric(sweBench?.full);
+    let sweBenchScore: number | null = null;
     if (verified !== null && verified > 0) {
-      score = Math.min(100, (verified / 70) * 100);
+      sweBenchScore = Math.min(100, (verified / sweBenchAnchor) * 100);
     } else if ((lite !== null && lite > 0) || (full !== null && full > 0)) {
       const benchScore = (lite ?? 0) > 0 ? (lite as number) : (full as number);
-      score = Math.min(100, (benchScore / 30) * 80);
+      sweBenchScore = Math.min(100, (benchScore / 30) * 80);
     }
+
+    // Terminal-Bench normalized contribution (or null when absent). Read from the
+    // CANONICAL top-level path data.metrics.terminal_bench only (normalizeInput
+    // has already canonicalized info.metrics to it) — never a nested copy.
+    const terminalBenchAccuracy = parseNumeric(metrics.info?.metrics?.terminal_bench);
+    const terminalBenchScore =
+      terminalBenchAccuracy !== null && terminalBenchAccuracy > 0
+        ? scoreTerminalBenchContribution(terminalBenchAccuracy)
+        : null;
+
+    // Blend the two signals into the agentic base (50 = neutral, no benchmark).
+    let benchmarkBase = 50;
+    if (sweBenchScore !== null && terminalBenchScore !== null) {
+      benchmarkBase =
+        (1 - TB_BLEND_WEIGHT) * sweBenchScore + TB_BLEND_WEIGHT * terminalBenchScore;
+    } else if (sweBenchScore !== null) {
+      benchmarkBase = sweBenchScore;
+    } else if (terminalBenchScore !== null) {
+      benchmarkBase = terminalBenchScore;
+    }
+
+    // ---- Heuristic bonuses --------------------------------------------------
+    // Accumulate raw bonus points from the non-benchmark signals, then combine
+    // them with the benchmark base per the calibration model (see below). These
+    // are the same signals/points as before; only how they fold into the final
+    // factor changed in v7.9.
+    let bonusPoints = 0;
 
     // Category bonuses - MORE GRANULAR
     const categoryBonus: Record<string, number> = {
@@ -518,29 +643,41 @@ export class RankingEngineV76 {
       "open-source-framework": 5,
       "app-builder": 3,
     };
-
     if (metrics.category && metrics.category in categoryBonus) {
-      score = Math.min(100, score + categoryBonus[metrics.category]);
+      bonusPoints += categoryBonus[metrics.category];
     }
 
     // Multi-file support bonus
     if (metrics.info?.technical?.multi_file_support) {
-      score = Math.min(100, score + 10);
+      bonusPoints += 10;
     }
 
     // Subprocess/automation capabilities
     const subprocess = metrics.info?.technical?.subprocess_support;
     if (subprocess) {
       const subprocessFeatures = Object.values(subprocess).filter(Boolean).length;
-      score = Math.min(100, score + subprocessFeatures * 2);
+      bonusPoints += subprocessFeatures * 2;
     }
 
     // Extract capability keywords from description
     const allText = `${metrics.info?.description || ""} ${metrics.info?.summary || ""} ${metrics.info?.overview || ""}`;
-    const capabilityBonus = extractCapabilityScore(allText);
-    score = Math.min(100, score + capabilityBonus * 0.3);
+    bonusPoints += extractCapabilityScore(allText) * 0.3;
 
-    return score;
+    // ---- Combine base + bonuses --------------------------------------------
+    if (this.calibration.bonusModel === "additive") {
+      // Legacy v7.8: add raw points and clip at 100. When the benchmark base is
+      // already high this re-saturates the factor and erases the SWE↔TB blend —
+      // reproduced here only to compute the v7.8 baseline in the impact analysis.
+      return Math.min(100, benchmarkBase + bonusPoints);
+    }
+
+    // v7.9 default: bonuses FILL a fraction of the remaining headroom above the
+    // benchmark base rather than adding-then-clipping. Because that fraction is
+    // < 1 for any realistic bonus stack, a higher benchmark base (stronger
+    // SWE+TB blend) always yields a higher final agentic score — the blend is
+    // never flattened away by the cap. Result stays within [benchmarkBase, 100].
+    const fill = Math.min(1, bonusPoints / AGENTIC_BONUS_HEADROOM_SCALE);
+    return benchmarkBase + (100 - benchmarkBase) * fill;
   }
 
   /**
@@ -1074,7 +1211,7 @@ export class RankingEngineV76 {
     return {
       version: ALGORITHM_VERSION,
       name: "Data-Driven Confidence Scoring with Missing Data Penalty",
-      description: "Penalizes tools lacking real-world metrics. Tools with verified data (GitHub, VS Code, npm, revenue) rank higher than those with only descriptions.",
+      description: "Penalizes tools lacking real-world metrics. Tools with verified data (GitHub, VS Code, npm, revenue) rank higher than those with only descriptions. Agentic capability blends two benchmark signals: SWE-bench Verified and Terminal-Bench (terminal-bench 2.1).",
       weights: ALGORITHM_V76_WEIGHTS,
       features: [
         "Data completeness scoring system (0-100%)",
@@ -1082,11 +1219,13 @@ export class RankingEngineV76 {
         "High-value metrics: GitHub stars, VS Code installs, npm downloads (25 pts each)",
         "Medium-value metrics: User count, revenue, SWE-bench (15 pts each)",
         "Low-value metrics: Description, features, company info, pricing (10 pts each)",
+        `Agentic capability blends SWE-bench + Terminal-Bench (default 0.6/${TB_BLEND_WEIGHT} split; whichever exists when only one is present)`,
+        `SWE-bench normalized against a ${SWE_BENCH_ANCHOR}% anchor so leaders stay unsaturated; heuristic bonuses fill remaining headroom (never re-cap the blend to 100)`,
         "All v7.3 features: Tiebreakers, differentiation, determinism",
         "Target: Data-backed tools rank higher than unverified tools",
         "Target: <20% duplicate scores, Top 10 all unique",
       ],
-      updatedAt: "2025-11-01",
+      updatedAt: "2026-07-18",
       improvements: [
         "Rewards tools with real-world verification metrics",
         "Penalizes tools with limited/missing data",

--- a/lib/ranking-metric-curves.test.ts
+++ b/lib/ranking-metric-curves.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   ARR_ANCHORS,
+  TERMINAL_BENCH_ANCHOR,
   USERS_ANCHORS,
   interpolateLogCurve,
   scoreArrContribution,
+  scoreTerminalBenchContribution,
   scoreUsersContribution,
 } from "./ranking-metric-curves";
 
@@ -165,6 +167,48 @@ describe("smoothing behaviour between anchors", () => {
     // New curve: the same 1-dollar step moves the score by < 0.001.
     const delta = scoreArrContribution(1_000_000) - scoreArrContribution(999_999);
     expect(Math.abs(delta)).toBeLessThan(0.001);
+  });
+});
+
+describe("scoreTerminalBenchContribution — linear curve against the 85% anchor", () => {
+  it("maps accuracy linearly below the anchor", () => {
+    // accuracy / 85 * 100
+    expect(scoreTerminalBenchContribution(85)).toBeCloseTo(100, 10);
+    expect(scoreTerminalBenchContribution(42.5)).toBeCloseTo(50, 10);
+    expect(scoreTerminalBenchContribution(17)).toBeCloseTo(20, 10);
+  });
+
+  it("gives today's leaderboard leaders near-full but sub-100 credit", () => {
+    // Claude Code #1 = 83.8%, Codex #2 = 83.1% (terminal-bench 2.1).
+    expect(scoreTerminalBenchContribution(83.8)).toBeCloseTo((83.8 / 85) * 100, 10);
+    expect(scoreTerminalBenchContribution(83.8)).toBeLessThan(100);
+    expect(scoreTerminalBenchContribution(83.1)).toBeLessThan(
+      scoreTerminalBenchContribution(83.8)
+    );
+  });
+
+  it("clamps at 100 at/above the anchor (headroom is only 85→100)", () => {
+    expect(scoreTerminalBenchContribution(TERMINAL_BENCH_ANCHOR)).toBe(100);
+    expect(scoreTerminalBenchContribution(90)).toBe(100);
+    expect(scoreTerminalBenchContribution(100)).toBe(100);
+  });
+
+  it("treats absent / invalid data as no-data (0), never a max score", () => {
+    expect(scoreTerminalBenchContribution(0)).toBe(0);
+    expect(scoreTerminalBenchContribution(-5)).toBe(0);
+    expect(scoreTerminalBenchContribution(Number.NaN)).toBe(0);
+    expect(scoreTerminalBenchContribution(Number.POSITIVE_INFINITY)).toBe(0);
+  });
+
+  it("is monotonically non-decreasing and bounded across the range", () => {
+    let previous = -1;
+    for (let acc = 0; acc <= 120; acc += 0.5) {
+      const score = scoreTerminalBenchContribution(acc);
+      expect(score).toBeGreaterThanOrEqual(previous);
+      expect(score).toBeGreaterThanOrEqual(0);
+      expect(score).toBeLessThanOrEqual(100);
+      previous = score;
+    }
   });
 });
 

--- a/lib/ranking-metric-curves.ts
+++ b/lib/ranking-metric-curves.ts
@@ -137,3 +137,40 @@ export function scoreArrContribution(arr: number): number {
 export function scoreUsersContribution(users: number): number {
   return interpolateLogCurve(users, USERS_ANCHORS);
 }
+
+/**
+ * Terminal-Bench normalization ceiling (linear anchor), in accuracy-percent.
+ *
+ * Terminal-Bench (https://www.tbench.ai/leaderboard/terminal-bench/2.1) reports
+ * a single bounded accuracy in [0, 100]. Unlike ARR/users — which are unbounded,
+ * geometrically-spaced business metrics that call for a log curve — a bounded
+ * accuracy is best mapped LINEARLY against a fixed anchor, mirroring how the
+ * agentic factor already normalizes SWE-bench (`verified / 70 * 100`).
+ *
+ * 85 is chosen as the anchor (rather than 100) so the current #1 row (Claude Code
+ * @ 83.8%, terminal-bench 2.1) lands at ~98.6 rather than 83.8 — i.e. today's
+ * best-in-class earns near-full credit while a small headroom (85→100) is
+ * reserved for future gains. The algorithm owner can retune this single constant
+ * to make the curve stricter (raise it) or more generous (lower it).
+ */
+export const TERMINAL_BENCH_ANCHOR = 85;
+
+/**
+ * Linear contribution curve for a Terminal-Bench accuracy percentage.
+ *
+ * Contract:
+ *   - Precondition: `accuracy` is a coerced number (already run through
+ *     `parseNumeric`); non-finite or ≤ 0 inputs are treated as "no data".
+ *   - Postcondition: result ∈ [0, 100], monotonically non-decreasing in
+ *     `accuracy`, equals 100 at/above `TERMINAL_BENCH_ANCHOR`, and returns 0 for
+ *     absent/invalid data (never a spurious max).
+ *
+ * @param accuracy - Terminal-Bench accuracy in percent (0–100), coerced
+ * @returns 0 for no-data, else `min(100, accuracy / TERMINAL_BENCH_ANCHOR * 100)`
+ */
+export function scoreTerminalBenchContribution(accuracy: number): number {
+  if (!Number.isFinite(accuracy) || accuracy <= 0) {
+    return 0;
+  }
+  return Math.min(100, (accuracy / TERMINAL_BENCH_ANCHOR) * 100);
+}

--- a/lib/terminal-bench-mapping.test.ts
+++ b/lib/terminal-bench-mapping.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit coverage for the hand-curated Terminal-Bench → ranked-tool attribution.
+ *
+ * Why: attribution is deliberately an explicit allowlist (no fuzzy matching), so
+ * these tests pin the two behaviours that keep the rankings honest — only
+ * allowlisted scaffolds earn credit, and each tool takes its single BEST row —
+ * plus the auditability guarantee that every non-attributed row is logged, never
+ * silently dropped.
+ *
+ * Test: pure, DB-free. Uses the real terminal-bench 2.1 leaderboard rows and a
+ * captured logger.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  EXCLUDED_SCAFFOLDS,
+  SCAFFOLD_TO_TOOL_SLUG,
+  type TerminalBenchRow,
+  selectBestRowsByTool,
+} from "./terminal-bench-mapping";
+
+/** The full terminal-bench 2.1 leaderboard (see the source capture). */
+const LEADERBOARD: TerminalBenchRow[] = [
+  { scaffold: "Claude Code", model: "Fable 5", accuracy: 83.8, as_of: "2026-06-07" },
+  { scaffold: "Codex", model: "GPT-5.5", accuracy: 83.1, as_of: "2026-05-01" },
+  { scaffold: "Terminus 2", model: "Fable 5", accuracy: 80.4, as_of: "2026-06-05" },
+  { scaffold: "Cursor CLI", model: "Grok 4.5", accuracy: 79.3, as_of: "2026-07-09" },
+  { scaffold: "Claude Code", model: "Opus 4.8", accuracy: 78.9, as_of: "2026-07-09" },
+  { scaffold: "Codex", model: "GPT-5.6 Terra", accuracy: 78.4, as_of: "2026-07-11" },
+  { scaffold: "Terminus 2", model: "GPT-5.5", accuracy: 78.0, as_of: "2026-05-01" },
+  { scaffold: "mini-SWE-agent", model: "Muse Spark 1.1", accuracy: 76.2, as_of: "2026-07-09" },
+  { scaffold: "Codex", model: "GPT-5.6 Luna", accuracy: 75.7, as_of: "2026-07-11" },
+  { scaffold: "Claude Code", model: "Sonnet 5", accuracy: 74.6, as_of: "2026-07-09" },
+  { scaffold: "Gemini CLI", model: "Gemini 3 Pro", accuracy: 65.8, as_of: "2026-05-01" },
+  { scaffold: "Claude Code", model: "GLM-5.1", accuracy: 58.7, as_of: "2026-05-01" },
+];
+
+function run(rows: TerminalBenchRow[]) {
+  const logs: string[] = [];
+  const matched = selectBestRowsByTool(rows, (m) => logs.push(m));
+  return { matched, logs };
+}
+
+describe("selectBestRowsByTool — best row per allowlisted tool", () => {
+  it("credits Claude Code with its highest row (Fable 5, 83.8%)", () => {
+    const { matched } = run(LEADERBOARD);
+    const cc = matched.get("claude-code");
+    expect(cc).toBeDefined();
+    expect(cc?.accuracy).toBe(83.8);
+    expect(cc?.scaffold).toBe("Claude Code");
+    expect(cc?.model).toBe("Fable 5");
+    expect(cc?.as_of).toBe("2026-06-07");
+  });
+
+  it("credits OpenAI Codex CLI with the Codex scaffold's highest row (GPT-5.5, 83.1%)", () => {
+    const { matched } = run(LEADERBOARD);
+    const codex = matched.get("openai-codex-cli");
+    expect(codex).toBeDefined();
+    expect(codex?.accuracy).toBe(83.1);
+    expect(codex?.model).toBe("GPT-5.5");
+  });
+
+  it("returns exactly the two allowlisted tools, nothing else", () => {
+    const { matched } = run(LEADERBOARD);
+    expect([...matched.keys()].sort()).toEqual(["claude-code", "openai-codex-cli"]);
+    expect(SCAFFOLD_TO_TOOL_SLUG).toEqual({
+      "Claude Code": "claude-code",
+      Codex: "openai-codex-cli",
+    });
+  });
+
+  it("ignores row order when picking the max", () => {
+    const reversed = [...LEADERBOARD].reverse();
+    const { matched } = run(reversed);
+    expect(matched.get("claude-code")?.accuracy).toBe(83.8);
+    expect(matched.get("openai-codex-cli")?.accuracy).toBe(83.1);
+  });
+});
+
+describe("exclusion + auditability — nothing is silently dropped", () => {
+  it("excludes Cursor CLI and Gemini CLI as likely-different products", () => {
+    const { matched, logs } = run(LEADERBOARD);
+    expect(matched.has("cursor")).toBe(false);
+    expect(matched.has("gemini-code-assist")).toBe(false);
+    expect(logs.some((l) => l.includes("EXCLUDED Cursor CLI"))).toBe(true);
+    expect(logs.some((l) => l.includes("EXCLUDED Gemini CLI"))).toBe(true);
+  });
+
+  it("excludes no-roster harnesses (Terminus 2, mini-SWE-agent)", () => {
+    const { logs } = run(LEADERBOARD);
+    expect(logs.some((l) => l.includes("EXCLUDED Terminus 2"))).toBe(true);
+    expect(logs.some((l) => l.includes("EXCLUDED mini-SWE-agent"))).toBe(true);
+    expect(EXCLUDED_SCAFFOLDS["Terminus 2"]).toContain("no ranked-tool counterpart");
+  });
+
+  it("logs every non-attributed row (excluded reasons + superseded losers)", () => {
+    const { matched, logs } = run(LEADERBOARD);
+    const attributedRows = matched.size; // 2 winners
+    // Every leaderboard row that is not a winning row must produce a log line.
+    const nonWinnerRows = LEADERBOARD.length - attributedRows;
+    const auditLines = logs.filter(
+      (l) => l.includes("EXCLUDED") || l.includes("SUPERSEDED")
+    );
+    expect(auditLines.length).toBe(nonWinnerRows);
+  });
+
+  it("logs an unknown scaffold with the generic no-allowlist-entry reason", () => {
+    const { matched, logs } = run([
+      { scaffold: "Totally New Agent", model: "X", accuracy: 90, as_of: "2026-07-01" },
+    ]);
+    expect(matched.size).toBe(0);
+    expect(logs[0]).toContain("no allowlist entry");
+  });
+});

--- a/lib/terminal-bench-mapping.ts
+++ b/lib/terminal-bench-mapping.ts
@@ -1,0 +1,157 @@
+/**
+ * Terminal-Bench → ranked-tool attribution (hand-curated, NO fuzzy matching).
+ *
+ * The Terminal-Bench leaderboard
+ * (https://www.tbench.ai/leaderboard/terminal-bench/2.1) lists results per
+ * SCAFFOLD (agent harness) × MODEL. Several scaffolds share a name-shape with a
+ * ranked tool but are NOT the same product, and several are generic harnesses
+ * with no ranked counterpart at all. Auto-aliasing by string similarity would
+ * silently mis-credit those rows, so attribution is an explicit allowlist that a
+ * human maintains — never inferred.
+ *
+ * Attribution rule (locked product decision):
+ *   1. Only scaffolds in `SCAFFOLD_TO_TOOL_SLUG` earn credit; every other row is
+ *      logged and dropped.
+ *   2. Each tool is credited with its BEST (highest-accuracy) row across all
+ *      underlying models; the winning scaffold+model is recorded so the stored
+ *      value stays auditable.
+ *
+ * Machine-readable source: as of terminal-bench 2.1 the leaderboard exposes no
+ * JSON/CSV endpoint (the page is server-rendered HTML; the underlying task suite
+ * lives at github.com/laude-institute/terminal-bench, and harness code at
+ * github.com/harbor-framework/harbor). Until a stable structured feed exists,
+ * the captured rows are persisted as a curated provenance file at
+ * `data/historical-metrics/sources/terminal-bench-2.1.json`; a future collector
+ * can replace the static capture without touching this mapping.
+ */
+
+/** Pinned leaderboard version this mapping was curated against. */
+export const TERMINAL_BENCH_VERSION = "terminal-bench 2.1";
+
+/** Canonical Terminal-Bench leaderboard URL (provenance `source`). */
+export const TERMINAL_BENCH_SOURCE_URL =
+  "https://www.tbench.ai/leaderboard/terminal-bench/2.1";
+
+/** A single leaderboard row: one scaffold running one model. */
+export interface TerminalBenchRow {
+  /** Scaffold / agent harness name exactly as it appears on the leaderboard. */
+  scaffold: string;
+  /** Underlying model name for this row. */
+  model: string;
+  /** Accuracy in percent (0–100). */
+  accuracy: number;
+  /** Row date (ISO `YYYY-MM-DD`) as published on the leaderboard. */
+  as_of: string;
+}
+
+/**
+ * HAND-CURATED allowlist: leaderboard scaffold → ranked `tools.slug`.
+ *
+ * `Codex` maps to `openai-codex-cli` (OpenAI Codex CLI) — the scaffold IS that
+ * product. `Claude Code` maps to its roster slug `claude-code`.
+ *
+ * NOT included, deliberately (see `EXCLUDED_SCAFFOLDS`): `Cursor CLI` and
+ * `Gemini CLI` — likely distinct products from the ranked "Cursor" (the editor)
+ * and "Google Gemini Code Assist", so aliasing them would mis-credit a different
+ * tool. Add an entry here ONLY after confirming the scaffold and the ranked tool
+ * are the same product.
+ */
+export const SCAFFOLD_TO_TOOL_SLUG: Readonly<Record<string, string>> = {
+  "Claude Code": "claude-code",
+  Codex: "openai-codex-cli",
+};
+
+/**
+ * Scaffolds intentionally excluded, each with the reason logged on exclusion.
+ * Two kinds: (a) name-collision products we must NOT auto-alias, and (b) generic
+ * harnesses with no ranked-tool counterpart.
+ */
+export const EXCLUDED_SCAFFOLDS: Readonly<Record<string, string>> = {
+  "Cursor CLI":
+    "likely a different product from the ranked 'Cursor' editor — no confirmed identity, do not auto-alias",
+  "Gemini CLI":
+    "likely a different product from the ranked 'Google Gemini Code Assist' — no confirmed identity, do not auto-alias",
+  "Terminus 2": "generic benchmark harness — no ranked-tool counterpart",
+  "mini-SWE-agent": "generic benchmark harness — no ranked-tool counterpart",
+};
+
+/** A best-row attribution result for one ranked tool. */
+export interface MatchedTerminalBench {
+  /** Ranked `tools.slug` this credit is attributed to. */
+  tool_slug: string;
+  /** Winning scaffold name. */
+  scaffold: string;
+  /** Winning model name (the highest-accuracy row for the scaffold). */
+  model: string;
+  /** Winning accuracy in percent. */
+  accuracy: number;
+  /** Winning row date. */
+  as_of: string;
+}
+
+/** Logger seam so callers (and tests) can capture the audit trail. */
+export type AuditLogger = (message: string) => void;
+
+/**
+ * Select the best (highest-accuracy) leaderboard row per ALLOWLISTED scaffold and
+ * attribute it to the mapped `tools.slug`.
+ *
+ * Every row that is not attributed is logged (never silently dropped):
+ *   - a known-excluded scaffold logs its curated reason,
+ *   - an unknown scaffold logs an "unmatched, no allowlist entry" note,
+ *   - a row beaten by a higher-accuracy row for the same scaffold logs as
+ *     superseded.
+ *
+ * Contract:
+ *   - Postcondition: the returned map has at most one entry per allowlisted
+ *     `tools.slug`, and that entry is the max-accuracy row for its scaffold. Ties
+ *     resolve to the first row seen (stable), keeping the result deterministic.
+ *
+ * @param rows - leaderboard rows (order-independent)
+ * @param log - audit sink (defaults to `console.log` for stdout auditability)
+ * @returns map keyed by `tools.slug`
+ */
+export function selectBestRowsByTool(
+  rows: readonly TerminalBenchRow[],
+  log: AuditLogger = console.log
+): Map<string, MatchedTerminalBench> {
+  const best = new Map<string, MatchedTerminalBench>();
+
+  for (const row of rows) {
+    const slug = SCAFFOLD_TO_TOOL_SLUG[row.scaffold];
+
+    if (!slug) {
+      const reason =
+        EXCLUDED_SCAFFOLDS[row.scaffold] ??
+        "unmatched scaffold — no allowlist entry";
+      log(
+        `[terminal-bench] EXCLUDED ${row.scaffold} (${row.model}, ${row.accuracy}%): ${reason}`
+      );
+      continue;
+    }
+
+    const current = best.get(slug);
+    if (!current || row.accuracy > current.accuracy) {
+      if (current) {
+        log(
+          `[terminal-bench] SUPERSEDED ${current.scaffold} (${current.model}, ${current.accuracy}%) ` +
+            `→ ${row.scaffold} (${row.model}, ${row.accuracy}%) for ${slug}`
+        );
+      }
+      best.set(slug, {
+        tool_slug: slug,
+        scaffold: row.scaffold,
+        model: row.model,
+        accuracy: row.accuracy,
+        as_of: row.as_of,
+      });
+    } else {
+      log(
+        `[terminal-bench] SUPERSEDED ${row.scaffold} (${row.model}, ${row.accuracy}%): ` +
+          `below best ${current.accuracy}% for ${slug}`
+      );
+    }
+  }
+
+  return best;
+}

--- a/scripts/analyze-terminal-bench-impact.ts
+++ b/scripts/analyze-terminal-bench-impact.ts
@@ -1,0 +1,194 @@
+#!/usr/bin/env tsx
+
+/**
+ * Terminal-Bench impact analysis (v7.9 calibration) — DRY-RUN, NO DB, NO PUBLISH.
+ *
+ * Produces ONE 3-way table over the full 31-tool roster to isolate Terminal-
+ * Bench's marginal effect on top of the anchor/cap retune:
+ *
+ *   A = baseline        : SWE anchor 70 + legacy additive-then-clip bonuses, NO TB
+ *                         (reproduces the v7.8-era behavior)
+ *   B = retuned, no TB   : SWE anchor 88 + headroom bonuses, NO TB
+ *                         (isolates what the calibration change alone does)
+ *   C = retuned + TB     : SWE anchor 88 + headroom bonuses + Terminal-Bench blend
+ *                         (the proposed v7.9 state)
+ *
+ * All three score the same in-memory roster with EMPTY base metrics (mirroring
+ * `scripts/generate-v76-rankings.ts --dry-run`), so the override fully drives the
+ * result. A/B differ only in engine calibration; B/C differ only in whether the
+ * Terminal-Bench leaves are present. Nothing touches the database.
+ *
+ * Run: npx tsx scripts/analyze-terminal-bench-impact.ts
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { slugify } from "@/lib/historical-metrics/slugify";
+import {
+  ALGORITHM_V76_WEIGHTS,
+  RankingEngineV76,
+  SWE_BENCH_ANCHOR,
+  TB_BLEND_WEIGHT,
+  type AgenticCalibration,
+  type ToolMetricsV76,
+} from "@/lib/ranking-algorithm-v76";
+import {
+  applyHistoricalMetricsOverride,
+  type HistoricalMetricsOverride,
+  type RankingSourceTool,
+} from "@/lib/services/ranking-generation.service";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PERIOD = "2026-06";
+const CLOCK = new Date(`${PERIOD}-01T00:00:00Z`);
+
+/** Tools that carry a Terminal-Bench leaf (the only ones B→C can move). */
+const MATCHED_SLUGS = ["claude-code", "openai-codex-cli"] as const;
+
+/** Calibration presets for the three columns. */
+const CAL_BASELINE: AgenticCalibration = { sweBenchAnchor: 70, bonusModel: "additive" };
+const CAL_RETUNED: AgenticCalibration = {}; // defaults = v7.9 (anchor 88, headroom)
+
+interface Row {
+  slug: string;
+  name: string;
+  score: number;
+  rank: number;
+  agentic: number;
+}
+
+function loadRoster(): RankingSourceTool[] {
+  const raw = JSON.parse(
+    readFileSync(join(ROOT, "data", "extracted-rankings", "2025-09.json"), "utf8")
+  ) as { rankings: Array<{ tool_id: string; tool_name: string }> };
+  return raw.rankings.map((r) => ({
+    id: String(r.tool_id),
+    name: r.tool_name,
+    slug: slugify(r.tool_name),
+    category: "code-editor",
+    status: "active",
+    data: { metrics: {} } as Record<string, unknown>,
+  }));
+}
+
+function loadOverride(): HistoricalMetricsOverride {
+  return JSON.parse(
+    readFileSync(join(ROOT, "data", "historical-metrics", `${PERIOD}.json`), "utf8")
+  ) as HistoricalMetricsOverride;
+}
+
+/** Deep-clone the override and delete every `terminal_bench` leaf. */
+function stripTerminalBench(o: HistoricalMetricsOverride): HistoricalMetricsOverride {
+  const clone = structuredClone(o);
+  for (const tool of Object.values(clone.tools)) {
+    if (tool.metrics && "terminal_bench" in tool.metrics) {
+      delete (tool.metrics as Record<string, unknown>)["terminal_bench"];
+    }
+  }
+  return clone;
+}
+
+/** Score + rank a board with a given calibration and override (pure, no DB). */
+function scoreBoard(
+  roster: RankingSourceTool[],
+  override: HistoricalMetricsOverride,
+  calibration: AgenticCalibration
+): Row[] {
+  const engine = new RankingEngineV76(ALGORITHM_V76_WEIGHTS, calibration);
+  const tools = applyHistoricalMetricsOverride(roster, override);
+  return tools
+    .map((tool) => {
+      const toolData = (tool.data ?? {}) as Record<string, unknown>;
+      const metrics: ToolMetricsV76 = {
+        tool_id: tool.id,
+        name: tool.name,
+        slug: tool.slug,
+        category: tool.category,
+        status: tool.status,
+        info: toolData,
+        metrics: (toolData["metrics"] as Record<string, unknown>) ?? {},
+      } as ToolMetricsV76;
+      const s = engine.calculateToolScore(metrics, CLOCK);
+      return {
+        slug: tool.slug,
+        name: tool.name,
+        score: s.overallScore,
+        agentic: s.factorScores.agenticCapability,
+      };
+    })
+    .sort((a, b) => b.score - a.score)
+    .map((r, i) => ({ ...r, rank: i + 1 }));
+}
+
+function main(): void {
+  const roster = loadRoster();
+  const full = loadOverride();
+  const stripped = stripTerminalBench(full);
+
+  const A = scoreBoard(roster, stripped, CAL_BASELINE);
+  const B = scoreBoard(roster, stripped, CAL_RETUNED);
+  const C = scoreBoard(roster, full, CAL_RETUNED);
+
+  const bySlug = (rows: Row[]) => new Map(rows.map((r) => [r.slug, r]));
+  const mA = bySlug(A);
+  const mB = bySlug(B);
+  const mC = bySlug(C);
+
+  console.log("\n" + "=".repeat(96));
+  console.log(`TERMINAL-BENCH 3-WAY IMPACT — period ${PERIOD} (DRY-RUN, no DB, no publish)`);
+  console.log(`A = baseline (SWE anchor 70, additive cap, no TB)`);
+  console.log(`B = retuned (SWE anchor ${SWE_BENCH_ANCHOR}, headroom cap, no TB)`);
+  console.log(`C = retuned + Terminal-Bench blend (TB_BLEND_WEIGHT=${TB_BLEND_WEIGHT})`);
+  console.log("=".repeat(96));
+  console.log(
+    "\n  rank(A→B→C)     score  A       B       C        Δrank      tool"
+  );
+  console.log("  " + "-".repeat(92));
+
+  // Order the table by the final (C) ranking.
+  let abRankMoves = 0;
+  let bcRankMoves = 0;
+  for (const c of C) {
+    const a = mA.get(c.slug)!;
+    const b = mB.get(c.slug)!;
+    if (a.rank !== b.rank) abRankMoves++;
+    if (b.rank !== c.rank) bcRankMoves++;
+    const mark = (MATCHED_SLUGS as readonly string[]).includes(c.slug) ? " *TB" : "";
+    const dAB = a.rank - b.rank;
+    const dBC = b.rank - c.rank;
+    const fmt = (d: number) => (d > 0 ? `+${d}` : d < 0 ? `${d}` : "·");
+    console.log(
+      `  #${String(a.rank).padStart(2)}→#${String(b.rank).padStart(2)}→#${String(c.rank).padStart(2)}   ` +
+        `${a.score.toFixed(3)} ${b.score.toFixed(3)} ${c.score.toFixed(3)}   ` +
+        `A→B ${fmt(dAB).padStart(3)} B→C ${fmt(dBC).padStart(3)}   ${c.name}${mark}`
+    );
+  }
+
+  // --- Matched-tool marginal detail --------------------------------------
+  console.log("\n" + "-".repeat(96));
+  console.log("MATCHED TOOLS — Terminal-Bench marginal effect (B→C), agentic factor + composite\n");
+  for (const slug of MATCHED_SLUGS) {
+    const a = mA.get(slug)!;
+    const b = mB.get(slug)!;
+    const c = mC.get(slug)!;
+    console.log(`  ${c.name} (${slug})`);
+    console.log(
+      `    agentic factor:  A=${a.agentic.toFixed(2)}  B=${b.agentic.toFixed(2)}  C=${c.agentic.toFixed(2)}` +
+        `   (B→C marginal +${(c.agentic - b.agentic).toFixed(2)})`
+    );
+    console.log(
+      `    composite:       A=${a.score.toFixed(3)}(#${a.rank})  B=${b.score.toFixed(3)}(#${b.rank})  C=${c.score.toFixed(3)}(#${c.rank})\n`
+    );
+  }
+
+  console.log("-".repeat(96));
+  console.log(
+    `SUMMARY: anchor/cap retune (A→B) moved ${abRankMoves} rank(s); ` +
+      `Terminal-Bench (B→C) moved ${bcRankMoves} rank(s).`
+  );
+  console.log("Dry-run analysis. Nothing was written to the database.\n");
+}
+
+main();


### PR DESCRIPTION
## Summary

Blends Terminal-Bench (tbench.ai 2.1) into the `agenticCapability` factor alongside SWE-bench, bumping `ALGORITHM_VERSION` v7.8 → v7.9. This adds a second, agentic-terminal-specific benchmark signal so the factor isn't reliant on SWE-bench alone.

## Decisions

- **Blend, not a new factor** — Terminal-Bench is folded into the existing `agenticCapability` factor rather than added as a standalone ranking factor.
- **Best-score-across-models attribution** — a company's Terminal-Bench contribution uses its best-scoring model/scaffold combination.
- **`TB_BLEND_WEIGHT = 0.4`** — Terminal-Bench contributes 40% of the blended benchmark signal, SWE-bench the remaining 60%.
- **Hand-curated scaffold→tool allowlist** — only scaffolds mapped with confidence are included: Claude Code, and Codex → OpenAI Codex CLI. Cursor CLI, Gemini CLI, Terminus 2, and mini-SWE-agent are excluded pending product confirmation of the correct company/tool mapping.

## Calibration caveat (read this before the impact numbers)

Making the Terminal-Bench signal actually move anything required recalibrating the agentic factor, because the old SWE-bench-only curve was saturated at the top:

- SWE-bench anchor raised **70 → 88** (de-saturates leaders so headroom exists above them).
- Bonus model changed from add-then-clip to a **headroom-fill model** (`AGENTIC_BONUS_HEADROOM_SCALE=60`), so a stronger benchmark base always raises the final factor instead of being clipped away.

**This recalibration is the larger board driver, not Terminal-Bench itself:**
- Anchor/cap retune (A→B): **13 ranks moved**
- Terminal-Bench blend (B→C): **5 ranks moved**

This was accepted deliberately by the owner as a necessary precondition for the Terminal-Bench signal to be effective — flagging it prominently here since it dominates the diff.

## Impact (3-way dry-run, no publish)

- OpenAI Codex CLI → **#2** (Terminal-Bench contributes +3.80 to agentic factor)
- Claude Code → **#7** (Terminal-Bench contributes +2.00 to agentic factor)
- Summary: anchor/cap retune (A→B) moved **13 ranks**; Terminal-Bench (B→C) moved **5 ranks**.

## Verification

- `tsc --noEmit` — 0 errors
- `npm run test:unit` — 295 passed | 77 skipped (77 pre-existing skips, unrelated to this change) | +5 new tests added
- Lint — new files clean; `npm run lint` is blocked project-wide by pre-existing issue #96 (unrelated to this PR)

## Not included

- No production publish/regeneration — requires `NODE_ENV=production` plus an explicit owner go-ahead, neither of which happened here.
- No UI badge for Terminal-Bench — deferred.
- Tunable levers are named constants for easy follow-up adjustment: `SWE_BENCH_ANCHOR`, `AGENTIC_BONUS_HEADROOM_SCALE`, `TB_BLEND_WEIGHT`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
